### PR TITLE
Re-export the entire json public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "readme.md"
 edition = "2018"
 
 [dependencies]
-error-iter = "0.1"
+error-iter = "=0.2.0"
 futures-executor-preview = "=0.3.0-alpha.19"
 futures-util-preview = { version = "=0.3.0-alpha.19", features = ["async-await", "select-macro"] }
 hyper = "=0.13.0-alpha.4"
@@ -17,11 +17,11 @@ hyper-tls = "=0.4.0-alpha.4"
 json = "=0.12.0"
 log = "=0.4.8"
 percent-encoding = "=2.1.0"
-thiserror = "=1.0.4"
+thiserror = "=1.0.6"
 tokio = "=0.2.0-alpha.6"
 
 [dev-dependencies]
 byteorder = "1.3"
-env_logger = "=0.7.1"
+env_logger = "0.7"
 getrandom = "0.1"
 randomize = "3.0"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Try the following sample code to get up and running quickly.
 
 ```rust
 use futures_util::stream::StreamExt;
-use json::object;
-use pubnub::{Error, PubNub};
+use pubnub::{json::object, Error, PubNub};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/examples/publish-subscribe.rs
+++ b/examples/publish-subscribe.rs
@@ -3,8 +3,7 @@
 #![forbid(unsafe_code)]
 
 use futures_util::stream::StreamExt;
-use json::object;
-use pubnub::{Error, PubNub};
+use pubnub::{json::object, Error, PubNub};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,7 @@
 //!
 //! ```
 //! use futures_util::stream::StreamExt;
-//! use json::object;
-//! use pubnub::PubNub;
+//! use pubnub::{json::object, PubNub};
 //!
 //! # async {
 //! let mut pubnub = PubNub::new("demo", "demo");
@@ -38,7 +37,7 @@ pub use crate::error::Error;
 pub use crate::message::{Message, Timetoken, Type};
 pub use crate::pubnub::{PubNub, PubNubBuilder};
 pub use crate::subscribe::Subscription;
-pub use json::JsonValue;
+pub use json;
 
 mod channel;
 mod error;
@@ -55,6 +54,7 @@ mod tests {
     use crate::pipe::{ListenerType, PipeMessage};
     use futures_util::future::FutureExt;
     use futures_util::stream::{FuturesUnordered, StreamExt};
+    use json::JsonValue;
     use log::debug;
     use randomize::PCG32;
     use tokio::runtime::current_thread::Runtime;

--- a/src/pubnub.rs
+++ b/src/pubnub.rs
@@ -71,8 +71,7 @@ impl PubNub {
     /// # Example
     ///
     /// ```
-    /// use json::object;
-    /// use pubnub::PubNub;
+    /// use pubnub::{json::object, PubNub};
     ///
     /// # async {
     /// let pubnub = PubNub::new("demo", "demo");
@@ -96,8 +95,7 @@ impl PubNub {
     /// # Example
     ///
     /// ```
-    /// use json::object;
-    /// use pubnub::PubNub;
+    /// use pubnub::{json::object, PubNub};
     ///
     /// # async {
     /// let pubnub = PubNub::new("demo", "demo");


### PR DESCRIPTION
This is needed because the PubNub public API depends on types from the json crate. It is bad form to require types from an external crate and not re-export those types. This allows a developer to use the `json` types without providing an explcit dependency on the crate (and potentially creating semver issues along the way).

Also updated examples to use the re-export.