### PR TITLE
Fix a panic in the HTTP client

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -11,8 +11,8 @@ pub(crate) async fn publish_request(
     url: Uri,
 ) -> Result<Timetoken, Error> {
     // Send network request
-    let res = http_client.get(url).await;
-    let mut body = res.unwrap().into_body();
+    let res = http_client.get(url).await?;
+    let mut body = res.into_body();
     let mut bytes = Vec::new();
 
     // Receive the response as a byte stream
@@ -38,8 +38,8 @@ pub(crate) async fn subscribe_request(
     url: Uri,
 ) -> Result<(Vec<Message>, Timetoken), Error> {
     // Send network request
-    let res = http_client.get(url).await;
-    let mut body = res.unwrap().into_body();
+    let res = http_client.get(url).await?;
+    let mut body = res.into_body();
     let mut bytes = Vec::new();
 
     // Receive the response as a byte stream

--- a/src/message.rs
+++ b/src/message.rs
@@ -121,6 +121,10 @@ impl Timetoken {
     /// where the message was created. Using an appropriate `region` is important for delivery
     /// semantics in a global distributed system.
     ///
+    /// # Errors
+    ///
+    /// Returns an error when the input `time` argument cannot be transformed into a duration.
+    ///
     /// # Example
     ///
     /// ```


### PR DESCRIPTION
- This happens when the connection is lost, e.g. switching networks on WiFi.
- Also adds a doc comment to prevent a new pedantic clippy error.