### PR TITLE
Fix CI

### DIFF
--- a/pubnub-core/src/data/presence.rs
+++ b/pubnub-core/src/data/presence.rs
@@ -25,7 +25,7 @@ pub mod respond_with {
         type Response;
     }
 
-    use super::*;
+    use super::{ChannelInfo, ChannelInfoWithOccupants, ChannelOccupantFullDetails, UUID};
 
     impl RespondWith for OccupancyOnly {
         type Response = ChannelInfo;

--- a/pubnub-core/src/mock/runtime.rs
+++ b/pubnub-core/src/mock/runtime.rs
@@ -8,7 +8,7 @@ use mockall::mock;
 
 mod gen {
     #![allow(missing_docs)]
-    use super::*;
+    use super::{mock, Future, Pin};
 
     mock! {
         pub Runtime {

--- a/pubnub-core/src/mock/transport.rs
+++ b/pubnub-core/src/mock/transport.rs
@@ -17,7 +17,7 @@ pub struct MockTransportError;
 
 mod gen {
     #![allow(missing_docs)]
-    use super::*;
+    use super::{mock, BoxFuture, MockTransportError};
 
     mock! {
         pub Transport {

--- a/pubnub-core/src/pubnub/mod.rs
+++ b/pubnub-core/src/pubnub/mod.rs
@@ -51,6 +51,10 @@ where
     TRuntime: Runtime + 'static,
 {
     /// Perform a transport call.
+    ///
+    /// # Errors
+    ///
+    /// Returns transport-specific errors.
     pub async fn call<TRequest>(
         &self,
         req: TRequest,

--- a/pubnub-core/src/pubnub/publish.rs
+++ b/pubnub-core/src/pubnub/publish.rs
@@ -13,6 +13,10 @@ where
 {
     /// Publish a message over the PubNub network.
     ///
+    /// # Errors
+    ///
+    /// Returns transport-specific errors.
+    ///
     /// # Example
     ///
     /// ```
@@ -53,6 +57,10 @@ where
     }
 
     /// Publish a message over the PubNub network with an extra metadata payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns transport-specific errors.
     ///
     /// # Example
     ///

--- a/pubnub-core/src/subscription/subscription.rs
+++ b/pubnub-core/src/subscription/subscription.rs
@@ -1,4 +1,4 @@
-use super::subscribe_loop::*;
+use super::subscribe_loop::{ChannelRx, ControlCommand, ControlTx, ListenerType, SubscriptionID};
 use crate::data::message::Message;
 use crate::runtime::Runtime;
 use futures_channel::mpsc;

--- a/pubnub-hyper/src/transport/hyper/presence.rs
+++ b/pubnub-hyper/src/transport/hyper/presence.rs
@@ -1,6 +1,6 @@
 //! Presence.
 
-use super::util::*;
+use super::util::{build_uri, handle_json_response, json_as_array, json_as_object};
 use super::{error, Hyper};
 use crate::core::data::{presence, request, response};
 use crate::core::json;

--- a/pubnub-hyper/src/transport/hyper/pubsub.rs
+++ b/pubnub-hyper/src/transport/hyper/pubsub.rs
@@ -1,6 +1,6 @@
 //! Publish / subscribe.
 
-use super::util::*;
+use super::util::{build_uri, handle_json_response};
 use super::{error, Hyper};
 use crate::core::data::{
     message::{Message, Type},


### PR DESCRIPTION
Context for this one is that builds with the nightly compiler have been failing for a few weeks because new default lints were enabled. But failures with nightly are ignored for other reasons. The new default lints recently got promoted to the beta compiler, so now CI is failing.