### PR TITLE
Eliminate duplicate linting instructions and reorganize for clarity (upstream branch)

### DIFF
--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -9,17 +9,16 @@
 //!
 //! Build your own client, or use preconfigured [`pubnub-hyper`](pubnub-hyper).
 
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
-#![allow(clippy::doc_markdown)]
-#![forbid(unsafe_code)]
-#![warn(
+#![deny(
+    clippy::all,
+    clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
-    missing_copy_implementations
+    missing_copy_implementations,
+    intra_doc_link_resolution_failure
 )]
+#![allow(clippy::doc_markdown)]
+#![forbid(unsafe_code)]
 
 pub use crate::builder::Builder;
 pub use crate::pubnub::PubNub;

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -39,17 +39,16 @@
 //! # };
 //! ```
 
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
-#![allow(clippy::doc_markdown)]
-#![forbid(unsafe_code)]
-#![warn(
+#![deny(
+    clippy::all,
+    clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
-    missing_copy_implementations
+    missing_copy_implementations,
+    intra_doc_link_resolution_failure
 )]
+#![allow(clippy::doc_markdown)]
+#![forbid(unsafe_code)]
 
 /// Re-export core for ease of use.
 pub mod core {

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -1,17 +1,16 @@
 //! # Shared PubNub utilities.
 //! May come in handy when implemeting custom transports.
 
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
-#![allow(clippy::doc_markdown)]
-#![forbid(unsafe_code)]
-#![warn(
+#![deny(
+    clippy::all,
+    clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
-    missing_copy_implementations
+    missing_copy_implementations,
+    intra_doc_link_resolution_failure
 )]
+#![allow(clippy::doc_markdown)]
+#![forbid(unsafe_code)]
 
 #[cfg(feature = "encoded-channels-list")]
 pub mod encoded_channels_list;


### PR DESCRIPTION
Supersedes and closes #43.
https://github.com/pubnub/rust/pull/43#issuecomment-604011048