### PR TITLE
Fix travis build

### DIFF
--- a/pubnub-core/src/data/channel/name.rs
+++ b/pubnub-core/src/data/channel/name.rs
@@ -80,35 +80,35 @@ mod tests {
     #[test]
     fn valid() {
         // Spec.
-        assert_eq!(is_valid(""), true);
-        assert_eq!(is_valid("qwe"), true);
-        assert_eq!(is_valid("123"), true);
+        assert!(is_valid(""));
+        assert!(is_valid("qwe"));
+        assert!(is_valid("123"));
     }
 
     #[test]
     fn valid_but_not_officially() {
         // Spec.
-        assert_eq!(is_valid("/"), true);
-        assert_eq!(is_valid("\\"), true);
-        assert_eq!(is_valid("."), true);
-        assert_eq!(is_valid("*"), true);
-        assert_eq!(is_valid(":"), true);
+        assert!(is_valid("/"));
+        assert!(is_valid("\\"));
+        assert!(is_valid("."));
+        assert!(is_valid("*"));
+        assert!(is_valid(":"));
 
         // Real world examples.
-        assert_eq!(is_valid("a.b"), true);
-        assert_eq!(is_valid("a:b"), true);
-        assert_eq!(is_valid("a/b"), true);
-        assert_eq!(is_valid("\\a"), true);
-        assert_eq!(is_valid("channels_.*"), true);
-        assert_eq!(is_valid("channels_*"), true);
+        assert!(is_valid("a.b"));
+        assert!(is_valid("a:b"));
+        assert!(is_valid("a/b"));
+        assert!(is_valid("\\a"));
+        assert!(is_valid("channels_.*"));
+        assert!(is_valid("channels_*"));
     }
 
     #[test]
     fn invalid() {
         // Spec.
-        assert_eq!(is_valid(","), false);
+        assert!(!is_valid(","));
 
         // Real world examples.
-        assert_eq!(is_valid("a,b"), false);
+        assert!(!is_valid("a,b"));
     }
 }

--- a/pubnub-core/src/data/channel/wildcard_spec.rs
+++ b/pubnub-core/src/data/channel/wildcard_spec.rs
@@ -130,18 +130,18 @@ mod tests {
 
     #[test]
     fn valid() {
-        assert_eq!(is_valid("stocks.*"), true); // from https://support.pubnub.com/support/solutions/articles/14000043663-how-do-i-subscribe-to-a-wildcard-channel-
-        assert_eq!(is_valid(""), true);
+        assert!(is_valid("stocks.*")); // from https://support.pubnub.com/support/solutions/articles/14000043663-how-do-i-subscribe-to-a-wildcard-channel-
+        assert!(is_valid(""));
     }
 
     #[test]
     fn valid_from_docs() {
         // From https://support.pubnub.com/support/solutions/articles/14000043664-how-many-channel-segments-are-supported-with-wildcard-subscribe-
 
-        assert_eq!(is_valid("a.*"), true);
-        assert_eq!(is_valid("a.b.*"), true);
-        assert_eq!(is_valid("a.b"), true);
-        assert_eq!(is_valid("a.b.c"), true);
+        assert!(is_valid("a.*"));
+        assert!(is_valid("a.b.*"));
+        assert!(is_valid("a.b"));
+        assert!(is_valid("a.b.c"));
 
         // Technically speaking, the last two examples are just single channels
         // without any wildcards, but you can subscribe to any of the above
@@ -152,12 +152,12 @@ mod tests {
     fn invalid_incorrect_from_docs() {
         // From https://support.pubnub.com/support/solutions/articles/14000043664-how-many-channel-segments-are-supported-with-wildcard-subscribe-
 
-        assert_eq!(is_valid("*"), false); // can not wildcard at the top level to subscribe to all channels
-        assert_eq!(is_valid(".*"), false); // can not start with a .
-        assert_eq!(is_valid("a.*.b"), false); // * must be at the end
-        assert_eq!(is_valid("a."), false); // the . must be followed by a * when it is at the end of the name
-        assert_eq!(is_valid("a*"), false); // * must always be preceded with a .
-        assert_eq!(is_valid("a*b"), false); // * must always be preceded with a . and .* must always be at the end
+        assert!(!is_valid("*")); // can not wildcard at the top level to subscribe to all channels
+        assert!(!is_valid(".*")); // can not start with a .
+        assert!(!is_valid("a.*.b")); // * must be at the end
+        assert!(!is_valid("a.")); // the . must be followed by a * when it is at the end of the name
+        assert!(!is_valid("a*")); // * must always be preceded with a .
+        assert!(!is_valid("a*b")); // * must always be preceded with a . and .* must always be at the end
 
         // NOTE: The above invalid channel names will actually succeed if you
         // attempt to subscribe to them. They will even succeed when you publish
@@ -182,8 +182,8 @@ mod tests {
         // two . characters (more than three segments) it will succeed, but
         // you will not be able to publish to those channels.
 
-        assert_eq!(is_valid("a.b.c.d"), false); // too many segments
-        assert_eq!(is_valid("a.b.c.*"), false); // too many segments
+        assert!(!is_valid("a.b.c.d")); // too many segments
+        assert!(!is_valid("a.b.c.*")); // too many segments
 
         // If you do attempt to publish to channel names with more than three
         // segments (three or more . delimiters), then you will receive a 400

--- a/pubnub-core/src/data/timetoken.rs
+++ b/pubnub-core/src/data/timetoken.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, SystemTimeError};
 /// This is the timetoken structure that PubNub uses as a stream index.
 /// It allows clients to resume streaming from where they left off for added
 /// resiliency.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy, Default)]
 pub struct Timetoken {
     /// Timetoken
     pub t: u64,
@@ -54,16 +54,6 @@ impl Timetoken {
         let t = (secs * 10_000_000) | (u64::from(nanos) / 100);
 
         Ok(Self { t, r: region })
-    }
-}
-
-impl Default for Timetoken {
-    #[must_use]
-    fn default() -> Self {
-        Self {
-            t: u64::default(),
-            r: u32::default(),
-        }
     }
 }
 

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -17,6 +17,7 @@
     missing_copy_implementations,
     rustdoc::broken_intra_doc_links
 )]
+#![allow(unknown_lints)]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]
 

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -15,7 +15,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-core/src/mock/runtime.rs
+++ b/pubnub-core/src/mock/runtime.rs
@@ -29,6 +29,6 @@ impl Runtime for MockRuntime {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        self.mock_workaround_spawn(Box::pin(future))
+        self.mock_workaround_spawn(Box::pin(future));
     }
 }

--- a/pubnub-core/src/subscription/subscribe_loop.rs
+++ b/pubnub-core/src/subscription/subscribe_loop.rs
@@ -161,7 +161,7 @@ enum ControlOutcome {
 }
 
 /// Handle a control command.
-async fn handle_control_command(
+fn handle_control_command(
     state_data: &mut StateData,
     msg: Option<ControlCommand>,
 ) -> ControlOutcome {

--- a/pubnub-core/src/subscription/subscribe_loop.rs
+++ b/pubnub-core/src/subscription/subscribe_loop.rs
@@ -161,7 +161,7 @@ enum ControlOutcome {
 }
 
 /// Handle a control command.
-fn handle_control_command(
+async fn handle_control_command(
     state_data: &mut StateData,
     msg: Option<ControlCommand>,
 ) -> ControlOutcome {

--- a/pubnub-core/src/subscription/subscription.rs
+++ b/pubnub-core/src/subscription/subscription.rs
@@ -55,9 +55,7 @@ impl<TRuntime: Runtime> Drop for Subscription<TRuntime> {
         // See: https://boats.gitlab.io/blog/post/poll-drop/
         self.runtime.spawn(async move {
             let drop_send_result = control_tx.send(command).await;
-            if is_drop_send_result_error(drop_send_result) {
-                panic!("Unable to unsubscribe");
-            }
+            assert!(!is_drop_send_result_error(drop_send_result), "Unable to unsubscribe");
         });
     }
 }

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -45,9 +45,10 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
+#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 /// Re-export core for ease of use.

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -45,7 +45,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -45,7 +45,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -6,7 +6,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -6,9 +6,10 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
+#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 /// Initialize the logger.

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -6,7 +6,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -7,7 +7,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -10,6 +10,7 @@
     rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
+#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "url-encoded-list")]

--- a/pubnub-util/src/pam_signature.rs
+++ b/pubnub-util/src/pam_signature.rs
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(
             format_plain_message(SAMPLE_REQUEST),
             EXPECTED_FORMATTED_BLOB,
-        )
+        );
     }
 
     #[test]
@@ -75,6 +75,6 @@ mod tests {
         assert_eq!(
             sign("wMfbo9G0xVUG8yfTfYw5qIdfJkTd7A", SAMPLE_REQUEST),
             "v2.W7Vim_epW4RyuT427E7cS2HiMADRP0wLP6-RkTWPtaM",
-        )
+        );
     }
 }

--- a/pubnub-util/src/uritemplate.rs
+++ b/pubnub-util/src/uritemplate.rs
@@ -121,7 +121,7 @@ impl UriTemplate {
 
     /// Delete all variable bindings.
     pub fn delete_all(&mut self) {
-        self.0.delete_all()
+        self.0.delete_all();
     }
 
     /// Build a URL from the template and bound variable values.


### PR DESCRIPTION
I noticed the Travis build was broken, and the fix was simply to change assertions of the form from `assert_eq!(is_valid(""), true);` to `assert!(is_valid(""));`, so I changed all instances like this. Running `cargo test` also revealed another simple error, where `broken_intra_doc_links` is now named `rustdoc::broken_intra_doc_links` and was causing test failures, so I updated those instances as well.