### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-- 1.46.0
+- 1.49.0
 - stable
 - beta
 - nightly

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The PubNub Rust SDK is based on Tokio `1.0`. This library uses `HTTP/2` to commu
 
 ## MSRV
 
-Supports Rust 1.46.0 and higher.
+Supports Rust 1.49.0 and higher.
 
 ## Get Started
 

--- a/pubnub-core/src/data/channel/name.rs
+++ b/pubnub-core/src/data/channel/name.rs
@@ -80,35 +80,35 @@ mod tests {
     #[test]
     fn valid() {
         // Spec.
-        assert_eq!(is_valid(""), true);
-        assert_eq!(is_valid("qwe"), true);
-        assert_eq!(is_valid("123"), true);
+        assert!(is_valid(""));
+        assert!(is_valid("qwe"));
+        assert!(is_valid("123"));
     }
 
     #[test]
     fn valid_but_not_officially() {
         // Spec.
-        assert_eq!(is_valid("/"), true);
-        assert_eq!(is_valid("\\"), true);
-        assert_eq!(is_valid("."), true);
-        assert_eq!(is_valid("*"), true);
-        assert_eq!(is_valid(":"), true);
+        assert!(is_valid("/"));
+        assert!(is_valid("\\"));
+        assert!(is_valid("."));
+        assert!(is_valid("*"));
+        assert!(is_valid(":"));
 
         // Real world examples.
-        assert_eq!(is_valid("a.b"), true);
-        assert_eq!(is_valid("a:b"), true);
-        assert_eq!(is_valid("a/b"), true);
-        assert_eq!(is_valid("\\a"), true);
-        assert_eq!(is_valid("channels_.*"), true);
-        assert_eq!(is_valid("channels_*"), true);
+        assert!(is_valid("a.b"));
+        assert!(is_valid("a:b"));
+        assert!(is_valid("a/b"));
+        assert!(is_valid("\\a"));
+        assert!(is_valid("channels_.*"));
+        assert!(is_valid("channels_*"));
     }
 
     #[test]
     fn invalid() {
         // Spec.
-        assert_eq!(is_valid(","), false);
+        assert!(!is_valid(","));
 
         // Real world examples.
-        assert_eq!(is_valid("a,b"), false);
+        assert!(!is_valid("a,b"));
     }
 }

--- a/pubnub-core/src/data/channel/wildcard_spec.rs
+++ b/pubnub-core/src/data/channel/wildcard_spec.rs
@@ -130,18 +130,18 @@ mod tests {
 
     #[test]
     fn valid() {
-        assert_eq!(is_valid("stocks.*"), true); // from https://support.pubnub.com/support/solutions/articles/14000043663-how-do-i-subscribe-to-a-wildcard-channel-
-        assert_eq!(is_valid(""), true);
+        assert!(is_valid("stocks.*")); // from https://support.pubnub.com/support/solutions/articles/14000043663-how-do-i-subscribe-to-a-wildcard-channel-
+        assert!(is_valid(""));
     }
 
     #[test]
     fn valid_from_docs() {
         // From https://support.pubnub.com/support/solutions/articles/14000043664-how-many-channel-segments-are-supported-with-wildcard-subscribe-
 
-        assert_eq!(is_valid("a.*"), true);
-        assert_eq!(is_valid("a.b.*"), true);
-        assert_eq!(is_valid("a.b"), true);
-        assert_eq!(is_valid("a.b.c"), true);
+        assert!(is_valid("a.*"));
+        assert!(is_valid("a.b.*"));
+        assert!(is_valid("a.b"));
+        assert!(is_valid("a.b.c"));
 
         // Technically speaking, the last two examples are just single channels
         // without any wildcards, but you can subscribe to any of the above
@@ -152,12 +152,12 @@ mod tests {
     fn invalid_incorrect_from_docs() {
         // From https://support.pubnub.com/support/solutions/articles/14000043664-how-many-channel-segments-are-supported-with-wildcard-subscribe-
 
-        assert_eq!(is_valid("*"), false); // can not wildcard at the top level to subscribe to all channels
-        assert_eq!(is_valid(".*"), false); // can not start with a .
-        assert_eq!(is_valid("a.*.b"), false); // * must be at the end
-        assert_eq!(is_valid("a."), false); // the . must be followed by a * when it is at the end of the name
-        assert_eq!(is_valid("a*"), false); // * must always be preceded with a .
-        assert_eq!(is_valid("a*b"), false); // * must always be preceded with a . and .* must always be at the end
+        assert!(!is_valid("*")); // can not wildcard at the top level to subscribe to all channels
+        assert!(!is_valid(".*")); // can not start with a .
+        assert!(!is_valid("a.*.b")); // * must be at the end
+        assert!(!is_valid("a.")); // the . must be followed by a * when it is at the end of the name
+        assert!(!is_valid("a*")); // * must always be preceded with a .
+        assert!(!is_valid("a*b")); // * must always be preceded with a . and .* must always be at the end
 
         // NOTE: The above invalid channel names will actually succeed if you
         // attempt to subscribe to them. They will even succeed when you publish
@@ -182,8 +182,8 @@ mod tests {
         // two . characters (more than three segments) it will succeed, but
         // you will not be able to publish to those channels.
 
-        assert_eq!(is_valid("a.b.c.d"), false); // too many segments
-        assert_eq!(is_valid("a.b.c.*"), false); // too many segments
+        assert!(!is_valid("a.b.c.d")); // too many segments
+        assert!(!is_valid("a.b.c.*")); // too many segments
 
         // If you do attempt to publish to channel names with more than three
         // segments (three or more . delimiters), then you will receive a 400

--- a/pubnub-core/src/data/timetoken.rs
+++ b/pubnub-core/src/data/timetoken.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, SystemTimeError};
 /// This is the timetoken structure that PubNub uses as a stream index.
 /// It allows clients to resume streaming from where they left off for added
 /// resiliency.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy, Default)]
 pub struct Timetoken {
     /// Timetoken
     pub t: u64,
@@ -54,16 +54,6 @@ impl Timetoken {
         let t = (secs * 10_000_000) | (u64::from(nanos) / 100);
 
         Ok(Self { t, r: region })
-    }
-}
-
-impl Default for Timetoken {
-    #[must_use]
-    fn default() -> Self {
-        Self {
-            t: u64::default(),
-            r: u32::default(),
-        }
     }
 }
 

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -10,6 +10,7 @@
 //! Build your own client, or use preconfigured [`pubnub-hyper`](pubnub-hyper).
 
 #![allow(unknown_lints)]
+#![allow(renamed_and_removed_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -17,6 +17,7 @@
     missing_copy_implementations,
     rustdoc::broken_intra_doc_links
 )]
+#![allow(unknown_lints)]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]
 

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -9,8 +9,11 @@
 //!
 //! Build your own client, or use preconfigured [`pubnub-hyper`](pubnub-hyper).
 
+// TODO: Remove these when minimum Rust version >1.59.0, when the name changed.
+// TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
+
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -15,7 +15,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -9,15 +9,15 @@
 //!
 //! Build your own client, or use preconfigured [`pubnub-hyper`](pubnub-hyper).
 
+#![allow(unknown_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
-#![allow(unknown_lints)]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]
 

--- a/pubnub-core/src/lib.rs
+++ b/pubnub-core/src/lib.rs
@@ -13,7 +13,6 @@
 // TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
-
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-core/src/mock/runtime.rs
+++ b/pubnub-core/src/mock/runtime.rs
@@ -29,6 +29,6 @@ impl Runtime for MockRuntime {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        self.mock_workaround_spawn(Box::pin(future))
+        self.mock_workaround_spawn(Box::pin(future));
     }
 }

--- a/pubnub-core/src/pubnub/tests.rs
+++ b/pubnub-core/src/pubnub/tests.rs
@@ -48,7 +48,7 @@ fn mocked_pubnub_publish_ok() {
             .expect("unexpected failure");
         assert_eq!(timetoken.t, 123);
         assert_eq!(timetoken.r, 456);
-    })
+    });
 }
 
 #[test]
@@ -185,7 +185,7 @@ fn mocked_pubnub_subscribe_ok() {
         })
         .unwrap();
 
-    pool.run()
+    pool.run();
 }
 
 #[allow(clippy::too_many_lines)]
@@ -333,5 +333,5 @@ fn mocked_pubnub_subscribe_trasport_error_does_not_stall_loop() {
         })
         .unwrap();
 
-    pool.run()
+    pool.run();
 }

--- a/pubnub-core/src/subscription/message_destinations.rs
+++ b/pubnub-core/src/subscription/message_destinations.rs
@@ -75,7 +75,7 @@ mod tests {
     }
 
     fn assert_iter_eq(m: &Message, expected: &[pubsub::SubscribeTo]) {
-        let iter = MessageDestinations::new(&m);
+        let iter = MessageDestinations::new(m);
         let vec: Vec<_> = iter.collect();
         assert_eq!(vec, expected);
     }

--- a/pubnub-core/src/subscription/subscribe_loop.rs
+++ b/pubnub-core/src/subscription/subscribe_loop.rs
@@ -161,6 +161,7 @@ enum ControlOutcome {
 }
 
 /// Handle a control command.
+#[allow(clippy::unused_async)]
 async fn handle_control_command(
     state_data: &mut StateData,
     msg: Option<ControlCommand>,

--- a/pubnub-core/src/subscription/subscribe_loop.rs
+++ b/pubnub-core/src/subscription/subscribe_loop.rs
@@ -161,7 +161,7 @@ enum ControlOutcome {
 }
 
 /// Handle a control command.
-async fn handle_control_command(
+fn handle_control_command(
     state_data: &mut StateData,
     msg: Option<ControlCommand>,
 ) -> ControlOutcome {

--- a/pubnub-core/src/subscription/subscribe_loop.rs
+++ b/pubnub-core/src/subscription/subscribe_loop.rs
@@ -161,7 +161,7 @@ enum ControlOutcome {
 }
 
 /// Handle a control command.
-fn handle_control_command(
+async fn handle_control_command(
     state_data: &mut StateData,
     msg: Option<ControlCommand>,
 ) -> ControlOutcome {

--- a/pubnub-core/src/subscription/subscription.rs
+++ b/pubnub-core/src/subscription/subscription.rs
@@ -55,9 +55,7 @@ impl<TRuntime: Runtime> Drop for Subscription<TRuntime> {
         // See: https://boats.gitlab.io/blog/post/poll-drop/
         self.runtime.spawn(async move {
             let drop_send_result = control_tx.send(command).await;
-            if is_drop_send_result_error(drop_send_result) {
-                panic!("Unable to unsubscribe");
-            }
+            assert!(!is_drop_send_result_error(drop_send_result), "Unable to unsubscribe");
         });
     }
 }

--- a/pubnub-core/src/subscription/subscription.rs
+++ b/pubnub-core/src/subscription/subscription.rs
@@ -16,10 +16,14 @@ use std::pin::Pin;
 /// [`PubNub::subscribe`]: crate::pubnub::PubNub::subscribe
 #[derive(Debug)]
 pub struct Subscription<TRuntime: Runtime> {
-    pub(crate) runtime: TRuntime, // Runtime to use for managing resources
-    pub(crate) destination: pubsub::SubscribeTo, // Subscription destination
-    pub(crate) id: SubscriptionID, // Unique identifier for the listener
-    pub(crate) control_tx: ControlTx, // For cleaning up resources at the subscribe loop when dropped
+    pub(crate) runtime: TRuntime,
+    // Runtime to use for managing resources
+    pub(crate) destination: pubsub::SubscribeTo,
+    // Subscription destination
+    pub(crate) id: SubscriptionID,
+    // Unique identifier for the listener
+    pub(crate) control_tx: ControlTx,
+    // For cleaning up resources at the subscribe loop when dropped
     pub(crate) channel_rx: ChannelRx, // Stream that produces messages
 }
 
@@ -55,7 +59,10 @@ impl<TRuntime: Runtime> Drop for Subscription<TRuntime> {
         // See: https://boats.gitlab.io/blog/post/poll-drop/
         self.runtime.spawn(async move {
             let drop_send_result = control_tx.send(command).await;
-            assert!(!is_drop_send_result_error(drop_send_result), "Unable to unsubscribe");
+            assert!(
+                !is_drop_send_result_error(drop_send_result),
+                "Unable to unsubscribe"
+            );
         });
     }
 }

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -43,7 +43,6 @@
 // TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
-
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -45,9 +45,10 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
+#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 /// Re-export core for ease of use.

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -39,16 +39,16 @@
 //! # };
 //! ```
 
+#![allow(unknown_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
-#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 /// Re-export core for ease of use.

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -45,7 +45,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -40,6 +40,7 @@
 //! ```
 
 #![allow(unknown_lints)]
+#![allow(renamed_and_removed_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -45,7 +45,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::default_trait_access, clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-hyper/src/lib.rs
+++ b/pubnub-hyper/src/lib.rs
@@ -39,8 +39,11 @@
 //! # };
 //! ```
 
+// TODO: Remove these when minimum Rust version >1.59.0, when the name changed.
+// TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
+
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-hyper/src/transport/hyper/history.rs
+++ b/pubnub-hyper/src/transport/hyper/history.rs
@@ -52,7 +52,7 @@ impl TransportService<request::GetHistory> for Hyper {
         .set_optional_scalar("end", end)
         .set_optional_scalar("include_meta", include_metadata)
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -85,7 +85,7 @@ impl TransportService<request::DeleteHistory> for Hyper {
                 .set_optional_scalar("start", start)
                 .set_optional_scalar("end", end)
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Prepare the request.
         let req = Request::builder()
@@ -122,7 +122,7 @@ impl TransportService<request::MessageCountsWithTimetoken> for Hyper {
                 .set_list("channels", channels)
                 .set_scalar("timetoken", timetoken)
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -157,7 +157,7 @@ impl TransportService<request::MessageCountsWithChannelTimetokens> for Hyper {
         .set_list("channels", names)
         .set_list("channelsTimetoken", timetokens)
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;

--- a/pubnub-hyper/src/transport/hyper/mod.rs
+++ b/pubnub-hyper/src/transport/hyper/mod.rs
@@ -74,6 +74,7 @@ impl HyperBuilder {
             .build::<_, Body>(https)
     }
 
+    // TODO: Remove random default UUID and require user to specify one. https://github.com/pubnub/rust/issues/66
     fn default_uuid() -> UUID {
         UUID::random()
     }

--- a/pubnub-hyper/src/transport/hyper/pam.rs
+++ b/pubnub-hyper/src/transport/hyper/pam.rs
@@ -40,7 +40,7 @@ impl TransportService<request::Grant> for Hyper {
             .set_scalar("signature", signature)
             .set_scalar("timestamp", timestamp.to_string())
             .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Prepare the request.
         let req = Request::builder()

--- a/pubnub-hyper/src/transport/hyper/presence.rs
+++ b/pubnub-hyper/src/transport/hyper/presence.rs
@@ -143,7 +143,7 @@ impl TransportService<request::SetState> for Hyper {
                 .set_scalar("uuid", uuid)
                 .set_scalar("state", json::stringify(state))
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -174,7 +174,7 @@ impl TransportService<request::GetState> for Hyper {
         .set_list_with_if_empty("channel-group", channel_groups, IfEmpty::Skip)
         .set_scalar("uuid", uuid)
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -208,7 +208,7 @@ impl TransportService<request::HereNow<presence::respond_with::OccupancyOnly>> f
         .set_list_with_if_empty("channel", channels, IfEmpty::Comma)
         .set_list_with_if_empty("channel-group", channel_groups, IfEmpty::Skip)
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -244,7 +244,7 @@ impl TransportService<request::HereNow<presence::respond_with::OccupancyAndUUIDs
         .set_list_with_if_empty("channel", channels, IfEmpty::Comma)
         .set_list_with_if_empty("channel-group", channel_groups, IfEmpty::Skip)
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -281,7 +281,7 @@ impl TransportService<request::HereNow<presence::respond_with::Full>> for Hyper 
         .set_list_with_if_empty("channel", channels, IfEmpty::Comma)
         .set_list_with_if_empty("channel-group", channel_groups, IfEmpty::Skip)
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -310,7 +310,7 @@ impl TransportService<request::GlobalHereNow<presence::respond_with::OccupancyOn
             UriTemplate::new("/v2/presence/sub-key/{sub_key}?disable_uuids=1&state=0")
                 .set_scalar("sub_key", self.subscribe_key.clone())
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -340,7 +340,7 @@ impl TransportService<request::GlobalHereNow<presence::respond_with::OccupancyAn
             UriTemplate::new("/v2/presence/sub-key/{sub_key}?disable_uuids=0&state=0")
                 .set_scalar("sub_key", self.subscribe_key.clone())
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -372,7 +372,7 @@ impl TransportService<request::GlobalHereNow<presence::respond_with::Full>> for 
             UriTemplate::new("/v2/presence/sub-key/{sub_key}?disable_uuids=0&state=1")
                 .set_scalar("sub_key", self.subscribe_key.clone())
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -398,7 +398,7 @@ impl TransportService<request::WhereNow> for Hyper {
             .set_scalar("sub_key", self.subscribe_key.clone())
             .set_scalar("uuid", uuid)
             .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -441,7 +441,7 @@ impl TransportService<request::Heartbeat> for Hyper {
                 .set_optional_scalar("heartbeat", heartbeat.map(|e|e.to_string()))
                 .set_scalar("state", json::stringify(state))
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;

--- a/pubnub-hyper/src/transport/hyper/pubsub.rs
+++ b/pubnub-hyper/src/transport/hyper/pubsub.rs
@@ -31,7 +31,7 @@ impl TransportService<request::Publish> for Hyper {
                 .set_scalar("uuid", self.uuid.clone())
                 .set_optional_scalar("meta", meta.map(json::stringify))
                 .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;
@@ -72,7 +72,7 @@ impl TransportService<request::Subscribe> for Hyper {
         .set_scalar("uuid", self.uuid.clone())
         .set_optional_scalar("heartbeat", heartbeat.map(|e| e.to_string()))
         .build();
-        let url = build_uri(&self, &path_and_query)?;
+        let url = build_uri(self, &path_and_query)?;
 
         // Send network request.
         let response = self.http_client.get(url).await?;

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -4,7 +4,6 @@
 // TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
-
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -1,6 +1,7 @@
 //! Test utilities used in PubNub crates suite.
 
 #![allow(unknown_lints)]
+#![allow(renamed_and_removed_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -6,7 +6,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -6,9 +6,10 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
+#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 /// Initialize the logger.

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -1,15 +1,15 @@
 //! Test utilities used in PubNub crates suite.
 
+#![allow(unknown_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
-#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 /// Initialize the logger.

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -6,7 +6,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-test-util/src/lib.rs
+++ b/pubnub-test-util/src/lib.rs
@@ -1,7 +1,10 @@
 //! Test utilities used in PubNub crates suite.
 
+// TODO: Remove these when minimum Rust version >1.59.0, when the name changed.
+// TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
+
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -7,7 +7,7 @@
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    broken_intra_doc_links
+    rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
 #![forbid(unsafe_code)]

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -1,8 +1,11 @@
 //! # Shared PubNub utilities.
 //! May come in handy when implemeting custom transports.
 
+// TODO: Remove these when minimum Rust version >1.59.0, when the name changed.
+// TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
+
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -2,6 +2,7 @@
 //! May come in handy when implemeting custom transports.
 
 #![allow(unknown_lints)]
+#![allow(renamed_and_removed_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -1,16 +1,16 @@
 //! # Shared PubNub utilities.
 //! May come in handy when implemeting custom transports.
 
+#![allow(unknown_lints)]
 #![deny(
     clippy::all,
     clippy::pedantic,
     missing_docs,
     missing_debug_implementations,
     missing_copy_implementations,
-    rustdoc::broken_intra_doc_links
+    broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
-#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "url-encoded-list")]

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -10,6 +10,7 @@
     rustdoc::broken_intra_doc_links
 )]
 #![allow(clippy::doc_markdown)]
+#![allow(unknown_lints)]
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "url-encoded-list")]

--- a/pubnub-util/src/lib.rs
+++ b/pubnub-util/src/lib.rs
@@ -5,7 +5,6 @@
 // TODO: `broken_intra_doc_links` below should become `rustdoc::broken_intra_doc_links`.
 #![allow(unknown_lints)]
 #![allow(renamed_and_removed_lints)]
-
 #![deny(
     clippy::all,
     clippy::pedantic,

--- a/pubnub-util/src/pam_signature.rs
+++ b/pubnub-util/src/pam_signature.rs
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(
             format_plain_message(SAMPLE_REQUEST),
             EXPECTED_FORMATTED_BLOB,
-        )
+        );
     }
 
     #[test]
@@ -75,6 +75,6 @@ mod tests {
         assert_eq!(
             sign("wMfbo9G0xVUG8yfTfYw5qIdfJkTd7A", SAMPLE_REQUEST),
             "v2.W7Vim_epW4RyuT427E7cS2HiMADRP0wLP6-RkTWPtaM",
-        )
+        );
     }
 }

--- a/pubnub-util/src/uritemplate.rs
+++ b/pubnub-util/src/uritemplate.rs
@@ -121,7 +121,7 @@ impl UriTemplate {
 
     /// Delete all variable bindings.
     pub fn delete_all(&mut self) {
-        self.0.delete_all()
+        self.0.delete_all();
     }
 
     /// Build a URL from the template and bound variable values.


### PR DESCRIPTION
I made changes to fix the linter/Clippy errors, as well as formatter errors that were causing the build to fail. Important to note:

- Minimum Rust version is now 1.49.0, due to features that cause warnings in 1.46.0 now.
- I widened what is allowed for unknown, renamed, and removed lints, due to a changed linter name that either breaks the minimum version, or the current version, mutually exclusive. I added TODOs noting when we can re-enable the check in the future.
- There were quite a few places where unnecessary dereferences were taking place, and semicolons added where no value was being returned and used.