### PR TITLE
deny warnings in code

### DIFF
--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -39,10 +39,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run cargo check tool to check if the codes are valid
       run: |
-       cargo check --verbose --workspace --all-targets --all-features
+       cargo check --workspace --all-targets --all-features
     - name: Run cargo clippy tool to check if all the best code practices are followed
       run: |
-       cargo clippy --verbose --workspace --all-targets --all-features
+       cargo clippy --workspace --all-targets --all-features -- -D warnings
     - name: Run cargo fmt tool to check if codes are well formatted 
       run: |
        cargo fmt --check --verbose --all

--- a/crates/contract-tests/tests/contract.rs
+++ b/crates/contract-tests/tests/contract.rs
@@ -43,18 +43,13 @@ async fn main() {
     PubnubWorld::cucumber()
         .before(|_feature, _rule, scenario, _world| {
             futures::FutureExt::boxed(async move {
-                if scenario
-                    .tags
-                    .iter()
-                    .find(|&t| t.starts_with("contract="))
-                    .is_some()
-                {
+                if scenario.tags.iter().any(|t| t.starts_with("contract=")) {
                     let tag = scenario
                         .tags
                         .iter()
                         .find(|&t| t.starts_with("contract="))
                         .unwrap();
-                    let splitted_values: Vec<&str> = tag.split("=").collect();
+                    let splitted_values: Vec<&str> = tag.split('=').collect();
                     if !splitted_values[1].is_empty() {
                         let script_name = splitted_values[1];
                         init_server(script_name.to_string()).await.unwrap();

--- a/crates/contract-tests/tests/contract.rs
+++ b/crates/contract-tests/tests/contract.rs
@@ -57,7 +57,7 @@ async fn main() {
                     let splitted_values: Vec<&str> = tag.split("=").collect();
                     if !splitted_values[1].is_empty() {
                         let script_name = splitted_values[1];
-                        init_server(script_name.to_string()).await;
+                        init_server(script_name.to_string()).await.unwrap();
                     }
                 }
             })


### PR DESCRIPTION
This PR contains:
 - denying warnings in code
 - fixing all existing warnings in current code.
 - removing `--verbose` argument because it seems to make error messages harder to understand