### PR TITLE
reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Feature list:
 :warning: We are under the development! ** Links below not work ** :warning:
 
 * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
-* [Rust docs](https://docs.rs/pubnub/latest/pubnub/]
+* [Rust docs](<https://www.docs.rs/pubnub/latest/pubnub>]
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Feature list:
 
 ## Documentation
 
-:warning: We are under the development! ** Links below not works ** :warning:
+:warning: We are under the development! ** Links below not work ** :warning:
 
 * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
 * [Rust docs](https://docs.rs/pubnub/latest/pubnub/]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ Feature list:
 
 ## Documentation
 
-* [API reference for Rust](TODO)
+:warning: We are under the development! ** Links below not works ** :warning:
+
+* [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
+* [Rust docs](https://docs.rs/pubnub/latest/pubnub/]
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ Feature list:
 
 ## Documentation
 
-:warning: We are under the development! ** Links below not work ** :warning:
+:warning: We are under the development! **Links below not work** :warning:
 
 * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
-* [Rust docs](<https://www.docs.rs/pubnub/latest/pubnub>]
+* [Rust docs](https://www.docs.rs/pubnub/latest/pubnub)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Feature list:
 
 ## Documentation
 
-:warning: We are under the development! **Links below not work** :warning:
+:warning: We are under the development! **Links below do not work** :warning:
 
 * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
 * [Rust docs](https://www.docs.rs/pubnub/latest/pubnub)

--- a/examples/publish.rs
+++ b/examples/publish.rs
@@ -1,7 +1,6 @@
-use std::env;
-
 use pubnub::{Keyset, PubNubClientBuilder};
 use serde::Serialize;
+use std::env;
 
 #[derive(Serialize)]
 struct Message {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -9,7 +9,6 @@
 /// This type is used to represent errors that can occur in the PubNub protocol.
 /// It is used as the error type for the [`Result`] type.
 ///
-/// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 /// # Examples
 /// ```
 /// use pubnub::core::PubNubError;
@@ -23,8 +22,9 @@
 ///   PubNubError::PublishError(_) => println!("Publish error"),
 ///   _ => println!("Other error"),
 /// });
-///
 /// ```
+///
+/// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 #[derive(thiserror::Error, Debug)]
 pub enum PubNubError {
     /// this error is returned when the transport layer fails

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -12,7 +12,7 @@
 /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
 /// # Examples
 /// ```
-/// use pubnub::PubNubError;
+/// use pubnub::core::PubNubError;
 ///
 /// fn foo() -> Result<(), PubNubError> {
 ///   Ok(())

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,17 +9,22 @@
 //!
 //! [`pubnub`]: ../index.html
 
+#[doc(inline)]
 pub use error::PubNubError;
 pub mod error;
 
+#[doc(inline)]
 pub use transport::Transport;
 pub mod transport;
 
+#[doc(inline)]
 pub use transport_request::{TransportMethod, TransportRequest};
 pub mod transport_request;
 
+#[doc(inline)]
 pub use transport_response::TransportResponse;
 pub mod transport_response;
 
+#[doc(inline)]
 pub use serialize::Serialize;
 pub mod serialize;

--- a/src/core/serialize.rs
+++ b/src/core/serialize.rs
@@ -20,14 +20,14 @@ use super::PubNubError;
 ///
 /// # Examples
 /// ```no_run
-/// use pubnub::Serialize;
+/// use pubnub::core::{Serialize, PubNubError};
 ///
 /// struct Foo {
 ///   bar: String,
 /// }
 ///  
 /// impl Serialize for Foo {
-///   fn serialize(self) -> Result<Vec<u8>, pubnub::PubNubError> {
+///   fn serialize(self) -> Result<Vec<u8>, PubNubError> {
 ///     Ok(format!("{{\"bar\":\"{}\"}}", self.bar).into_bytes())
 ///   }
 /// }
@@ -45,12 +45,12 @@ pub trait Serialize {
     ///
     /// # Examples
     /// ```
-    /// use pubnub::Serialize;
+    /// use pubnub::core::{Serialize, PubNubError};
     ///
     /// struct Foo;
     ///
     /// impl Serialize for Foo {
-    ///    fn serialize(self) -> Result<Vec<u8>, pubnub::PubNubError> {
+    ///    fn serialize(self) -> Result<Vec<u8>, PubNubError> {
     ///         Ok(vec![1, 2, 3])
     ///    }
     /// }

--- a/src/core/serialize.rs
+++ b/src/core/serialize.rs
@@ -16,8 +16,6 @@ use super::PubNubError;
 /// You can implement this trait for your own types, or use the provided
 /// implementations for [`Into<Vec<u8>>`].
 ///
-/// [`serialize`]: #tymethod.serialize
-///
 /// # Examples
 /// ```no_run
 /// use pubnub::core::{Serialize, PubNubError};
@@ -35,13 +33,13 @@ use super::PubNubError;
 /// let bytes = Foo { bar: "baz".into() };
 /// assert_eq!(bytes.serialize().unwrap(), b"{\"bar\":\"baz\"}".to_vec());
 /// ```
+///
+/// [`serialize`]: #tymethod.serialize
 pub trait Serialize {
     /// Serialize the value
     ///
     /// # Errors
     /// Should return an [`PubNubError::SerializeError`] if the value cannot be serialized.
-    ///
-    /// [`PubNubError::SerializeError`]: ../error/enum.PubNubError.html#variant.SerializeError
     ///
     /// # Examples
     /// ```
@@ -54,6 +52,8 @@ pub trait Serialize {
     ///         Ok(vec![1, 2, 3])
     ///    }
     /// }
-    ///```
+    /// ```
+    ///
+    /// [`PubNubError::SerializeError`]: ../error/enum.PubNubError.html#variant.SerializeError
     fn serialize(self) -> Result<Vec<u8>, PubNubError>;
 }

--- a/src/core/transport.rs
+++ b/src/core/transport.rs
@@ -18,7 +18,7 @@ use super::{transport_response::TransportResponse, PubNubError, TransportRequest
 ///
 /// # Examples
 /// ```
-/// use pubnub::{Transport, TransportRequest, TransportResponse, PubNubError};
+/// use pubnub::core::{Transport, TransportRequest, TransportResponse, PubNubError};
 ///
 /// struct MyTransport;
 ///

--- a/src/core/transport.rs
+++ b/src/core/transport.rs
@@ -14,8 +14,6 @@ use super::{transport_response::TransportResponse, PubNubError, TransportRequest
 /// You can implement this trait for your own types, or use one of the provided
 /// features to use a transport library.
 ///
-/// [`PubNub API`]: https://www.pubnub.com/docs
-///
 /// # Examples
 /// ```
 /// use pubnub::core::{Transport, TransportRequest, TransportResponse, PubNubError};
@@ -31,6 +29,8 @@ use super::{transport_response::TransportResponse, PubNubError, TransportRequest
 ///    }
 /// }
 /// ```
+///
+/// [`PubNub API`]: https://www.pubnub.com/docs
 #[async_trait::async_trait]
 pub trait Transport {
     /// Send a request to the [`PubNub API`].

--- a/src/core/transport_request.rs
+++ b/src/core/transport_request.rs
@@ -17,11 +17,11 @@ use std::{collections::HashMap, fmt::Display};
 /// [`TransportRequest`]: struct.TransportRequest.html
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub enum TransportMethod {
-    /// TODO: Add docs
+    /// The GET method.
     #[default]
     Get,
 
-    /// TODO: Add docs
+    /// The POST method.
     Post,
 }
 

--- a/src/dx/publish.rs
+++ b/src/dx/publish.rs
@@ -1,4 +1,15 @@
-//! TODO: Add documentation
+//! Publish module.
+//!
+//! Publish message to a channel.
+//! The publish module contains the [`PublishMessageBuilder`] and [`PublishMessageViaChannelBuilder`].
+//! The [`PublishMessageBuilder`] is used to publish a message to a channel.
+//!
+//! This module is accountable for publishing a message to a channel of the [`PubNub`] network.
+//!
+//! [`PublishMessageBuilder`]: crate::dx::publish::PublishMessageBuilder]
+//! [`PublishMessageViaChannelBuilder`]: crate::dx::publish::PublishMessageViaChannelBuilder]
+//! [`PubNub`]:https://www.pubnub.com/
+
 use crate::{
     core::{PubNubError, Transport, TransportMethod, TransportRequest},
     dx::PubNubClient,
@@ -9,10 +20,36 @@ use std::collections::HashMap;
 use std::ops::Not;
 use urlencoding::encode;
 
-/// TODO: Add documentation
-pub type MessageType = String;
-
-/// TODO: Add documentation
+/// The [`PublishMessageBuilder`] is used to publish a message to a channel.
+///
+/// This struct is used to publish a message to a channel. It is used by the [`publish`] method of the [`PubNubClient`].
+/// The [`publish`] method is used to publish a message to a channel.
+/// The [`PublishMessageBuilder`] is used to build the request to be sent to the [`PubNub`] network.
+///
+/// # Examples
+/// ```rust
+/// # use pubnub::{PubNubClientBuilder, Keyset};
+///
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut pubnub = // PubNubClient
+/// # PubNubClientBuilder::with_reqwest_transport()
+/// #     .with_keyset(Keyset{
+/// #         subscribe_key: "demo",
+/// #         publish_key: Some("demo"),
+/// #         secret_key: None,
+/// #     })
+/// #     .with_user_id("user_id")
+/// #     .build()?;
+///
+/// pubnub.publish_message("hello world!")
+///     .channel("my_channel")
+///     .execute()
+///     .await?;
+///
+/// # Ok(())
+/// # }
+/// ```
 pub struct PublishMessageBuilder<'pub_nub, T, M>
 where
     T: Transport,
@@ -28,7 +65,9 @@ where
     T: Transport,
     M: Serialize,
 {
-    /// TODO: Add documentation
+    /// The [`channel`] method is used to set the channel to publish the message to.
+    ///
+    /// [`channel`]: crate::dx::publish::PublishMessageBuilder::channel
     pub fn channel<S>(self, channel: S) -> PublishMessageViaChannelBuilder<'pub_nub, T, M>
     where
         S: Into<String>,
@@ -43,9 +82,40 @@ where
     }
 }
 
-/// TODO: Add documentation
-// TODO: use dead codes
-#[allow(dead_code)]
+/// The [`PublishMessageViaChannelBuilder`] is used to publish a message to a channel.
+/// This struct is used to publish a message to a channel. It is used by the [`publish_message`] method of the [`PubNubClient`].
+///
+/// This is next step in the publish process. The [`PublishMessageViaChannelBuilder`] is used to build the request to be sent to the [`PubNub`] network.
+///
+/// [`PublishMessageViaChannelBuilder`]: crate::dx::publish::PublishMessageViaChannelBuilder
+/// [`publish_message`]: crate::dx::PubNubClient::publish_message
+/// [`PubNub`]:https://www.pubnub.com/
+/// [`PubNubClient`]: crate::dx::PubNubClient
+///
+/// # Examples
+/// ```rust
+/// # use pubnub::{PubNubClientBuilder, Keyset};
+///
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut pubnub = // PubNubClient
+/// # PubNubClientBuilder::with_reqwest_transport()
+/// #     .with_keyset(Keyset{
+/// #         subscribe_key: "demo",
+/// #         publish_key: Some("demo"),
+/// #         secret_key: None,
+/// #     })
+/// #     .with_user_id("user_id")
+/// #     .build()?;
+///
+/// pubnub.publish_message("hello world!")
+///     .channel("my_channel")
+///     .execute()
+///     .await?;
+///
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Builder)]
 #[builder(pattern = "owned", build_fn(private))]
 pub struct PublishMessageViaChannel<'pub_nub, T, M>
@@ -55,32 +125,47 @@ where
 {
     #[builder(setter(custom))]
     pub_nub_client: &'pub_nub PubNubClient<T>,
+
     #[builder(setter(custom))]
     seqn: u16,
-    /// TODO: Add documentation
+
+    /// Message to publish
     message: M,
-    /// TODO: Add documentation
+
+    /// Channel to publish to
     #[builder(setter(into))]
     channel: String,
-    /// TODO: Add documentation
+
+    /// Switch that decide if the message should be stored in history
     #[builder(setter(strip_option), default = "None")]
     store: Option<bool>,
-    /// TODO: Add documentation
+
+    /// Switch that decide if the transaction should be replicated
+    /// following the PubNub replication rules.
+    ///
+    /// See more at [`PubNub replication rules`]
+    ///
+    /// [`PubNub replication rules`]:https://www.pubnub.com/pricing/transaction-classification/
     #[builder(default = "true")]
     replicate: bool,
-    /// TODO: Add documentation
+
+    /// Set a per-message TTL time to live in storage.
     #[builder(setter(strip_option), default = "None")]
     ttl: Option<u32>,
-    /// TODO: Add documentation
+
+    /// Switch that decide if the message should be published using POST method.
     #[builder(setter(strip_option), default = "false")]
     use_post: bool,
-    /// TODO: Add documentation
+
+    /// Object to send additional information about the message.
     #[builder(setter(strip_option), default = "None")]
     meta: Option<HashMap<String, String>>,
-    /// TODO: Add documentation
+
+    /// Space ID to publish to.
     #[builder(setter(strip_option), default = "None")]
     space_id: Option<String>,
-    /// TODO: Add documentation
+
+    /// Message type to publish.
     #[builder(setter(strip_option), default = "None")]
     message_type: Option<String>,
 }
@@ -186,7 +271,34 @@ where
     T: Transport,
     M: Serialize,
 {
-    /// TODO: Add documentation
+    /// Execute the request and return the result.
+    /// This method is asynchronous and will return a future.
+    /// The future will resolve to a [`PublishResult`] or [`PubNubError`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use pubnub::{PubNubClientBuilder, Keyset};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut pubnub = // PubNubClient
+    /// # PubNubClientBuilder::with_reqwest_transport()
+    /// #     .with_keyset(Keyset{
+    /// #         subscribe_key: "demo",
+    /// #         publish_key: Some("demo"),
+    /// #         secret_key: None,
+    /// #      })
+    /// #     .with_user_id("uuid")
+    /// #     .build()?;
+    ///
+    /// pubnub.publish_message("Hello, world!")
+    ///    .channel("my_channel")
+    ///    .execute()
+    ///    .await?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn execute(self) -> Result<PublishResult, PubNubError> {
         let instance = self
             .build()
@@ -200,7 +312,8 @@ where
     }
 }
 
-/// TODO: Add documentation
+/// Result of a publish request.
+/// This type is a placeholder for future functionality.
 #[derive(Debug)]
 pub struct PublishResult;
 
@@ -217,7 +330,7 @@ where
         ret
     }
 
-    /// TODO: Add documentation
+    /// Create a new publish message builder.
     pub fn publish_message<M>(&mut self, message: M) -> PublishMessageBuilder<T, M>
     where
         M: Serialize,

--- a/src/dx/publish.rs
+++ b/src/dx/publish.rs
@@ -11,9 +11,8 @@
 //! [`PubNub`]:https://www.pubnub.com/
 
 use crate::{
-    core::{PubNubError, Transport, TransportMethod, TransportRequest},
+    core::{PubNubError, Serialize, Transport, TransportMethod, TransportRequest},
     dx::PubNubClient,
-    Serialize,
 };
 use derive_builder::Builder;
 use std::collections::HashMap;

--- a/src/dx/publish.rs
+++ b/src/dx/publish.rs
@@ -25,11 +25,6 @@ use urlencoding::encode;
 /// The [`publish_message`] method is used to publish a message to a channel.
 /// The [`PublishMessageBuilder`] is used to build the request to be sent to the [`PubNub`] network.
 ///
-/// [`PublishMessageBuilder`]: crate::dx::publish::PublishMessageBuilder]
-/// [`publish_message`]: crate::dx::PubNubClient::publish_message`
-/// [`PubNubClient`]: crate::dx::PubNubClient
-/// [`PubNub`]:https://www.pubnub.com/
-///
 /// # Examples
 /// ```rust
 /// # use pubnub::{PubNubClientBuilder, Keyset};
@@ -54,6 +49,11 @@ use urlencoding::encode;
 /// # Ok(())
 /// # }
 /// ```
+///
+/// [`PublishMessageBuilder`]: crate::dx::publish::PublishMessageBuilder]
+/// [`publish_message`]: crate::dx::PubNubClient::publish_message`
+/// [`PubNubClient`]: crate::dx::PubNubClient
+/// [`PubNub`]:https://www.pubnub.com/
 pub struct PublishMessageBuilder<'pub_nub, T, M>
 where
     T: Transport,
@@ -91,11 +91,6 @@ where
 ///
 /// This is next step in the publish process. The [`PublishMessageViaChannelBuilder`] is used to build the request to be sent to the [`PubNub`] network.
 ///
-/// [`PublishMessageViaChannelBuilder`]: crate::dx::publish::PublishMessageViaChannelBuilder
-/// [`publish_message`]: crate::dx::PubNubClient::publish_message
-/// [`PubNub`]:https://www.pubnub.com/
-/// [`PubNubClient`]: crate::dx::PubNubClient
-///
 /// # Examples
 /// ```rust
 /// # use pubnub::{PubNubClientBuilder, Keyset};
@@ -120,6 +115,11 @@ where
 /// # Ok(())
 /// # }
 /// ```
+///
+/// [`PublishMessageViaChannelBuilder`]: crate::dx::publish::PublishMessageViaChannelBuilder
+/// [`publish_message`]: crate::dx::PubNubClient::publish_message
+/// [`PubNub`]:https://www.pubnub.com/
+/// [`PubNubClient`]: crate::dx::PubNubClient
 #[derive(Builder)]
 #[builder(pattern = "owned", build_fn(private))]
 pub struct PublishMessageViaChannel<'pub_nub, T, M>
@@ -303,6 +303,9 @@ where
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// [`PublishResult`]: struct.PublishResult.html
+    /// [`PubNubError`]: enum.PubNubError.html
     pub async fn execute(self) -> Result<PublishResult, PubNubError> {
         let instance = self
             .build()

--- a/src/dx/publish.rs
+++ b/src/dx/publish.rs
@@ -21,9 +21,14 @@ use urlencoding::encode;
 
 /// The [`PublishMessageBuilder`] is used to publish a message to a channel.
 ///
-/// This struct is used to publish a message to a channel. It is used by the [`publish`] method of the [`PubNubClient`].
-/// The [`publish`] method is used to publish a message to a channel.
+/// This struct is used to publish a message to a channel. It is used by the [`publish_message`] method of the [`PubNubClient`].
+/// The [`publish_message`] method is used to publish a message to a channel.
 /// The [`PublishMessageBuilder`] is used to build the request to be sent to the [`PubNub`] network.
+///
+/// [`PublishMessageBuilder`]: crate::dx::publish::PublishMessageBuilder]
+/// [`publish_message`]: crate::dx::PubNubClient::publish_message`
+/// [`PubNubClient`]: crate::dx::PubNubClient
+/// [`PubNub`]:https://www.pubnub.com/
 ///
 /// # Examples
 /// ```rust

--- a/src/dx/pubnub_client.rs
+++ b/src/dx/pubnub_client.rs
@@ -8,7 +8,7 @@
 //! [`PubNub API`]: https://www.pubnub.com/docs
 //! [`pubnub`]: ../index.html
 
-use crate::{core::Transport, transport::middleware::PubNubMiddleware, PubNubError};
+use crate::{core::PubNubError, core::Transport, transport::middleware::PubNubMiddleware};
 use derive_builder::Builder;
 
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -32,6 +32,7 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 ///
 /// // note that `with_reqwest_transport` requires `reqwest` feature
 /// // to be enabled (default)
+/// # fn main() -> Result<(), pubnub::core::PubNubError> {
 /// let client = PubNubClientBuilder::with_reqwest_transport()
 ///    .with_keyset(Keyset {
 ///         publish_key: Some("pub-c-abc123"),
@@ -39,7 +40,10 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 ///         secret_key: None,
 ///    })
 ///    .with_user_id("my-user-id")
-///    .build();
+///    .build()?;
+///
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// or using own [`Transport`] implementation
@@ -49,12 +53,11 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 /// ```
 /// use pubnub::{PubNubClient, Keyset};
 ///
-/// # use pubnub::core::{Transport, TransportRequest, TransportResponse};
+/// # use pubnub::core::{Transport, TransportRequest, TransportResponse, PubNubError};
 /// # struct MyTransport;
 /// # #[async_trait::async_trait]
 /// # impl Transport for MyTransport {
-/// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse,
-/// pubnub::PubNubError> {
+/// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse, PubNubError> {
 /// #         unimplemented!()
 /// #     }
 /// # }
@@ -64,6 +67,7 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 /// #     }
 /// # }
 ///
+/// # fn main() -> Result<(), pubnub::core::PubNubError> {
 /// // note that MyTransport must implement `Transport` trait
 /// let transport = MyTransport::new();
 ///
@@ -74,7 +78,10 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 ///         secret_key: None,
 ///    })
 ///    .with_user_id("my-user-id")
-///    .build();
+///    .build()?;
+///
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # See also
@@ -118,11 +125,11 @@ where
     /// ```
     /// use pubnub::{PubNubClient, Keyset};
     ///
-    /// # use pubnub::core::{Transport, TransportRequest, TransportResponse};
+    /// # use pubnub::core::{Transport, TransportRequest, TransportResponse, PubNubError};
     /// # struct MyTransport;
     /// # #[async_trait::async_trait]
     /// # impl Transport for MyTransport {
-    /// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse, pubnub::PubNubError> {
+    /// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse, PubNubError> {
     /// #         unimplemented!()
     /// #     }
     /// # }
@@ -132,6 +139,7 @@ where
     /// #     }
     /// # }
     ///
+    /// # fn main() -> Result<(), pubnub::core::PubNubError> {
     /// // note that MyTransport must implement `Transport` trait
     /// let transport = MyTransport::new();
     ///
@@ -142,7 +150,10 @@ where
     ///        secret_key: None,
     ///     })
     ///     .with_user_id("my-user-id")
-    ///     .build();
+    ///     .build()?;
+    ///
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_transport(transport: T) -> PubNubClientBuilder<T> {
         PubNubClientBuilder {
@@ -242,12 +253,11 @@ where
     /// ```
     /// use pubnub::PubNubClientBuilder;
     ///
-    /// # use pubnub::core::{Transport, TransportRequest, TransportResponse};
+    /// # use pubnub::core::{Transport, TransportRequest, TransportResponse, PubNubError};
     /// # struct MyTransport;
     /// # #[async_trait::async_trait]
     /// # impl Transport for MyTransport {
-    /// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse,
-    /// pubnub::PubNubError> {
+    /// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse, PubNubError> {
     /// #         unimplemented!()
     /// #     }
     /// # }
@@ -272,12 +282,11 @@ where
     /// ```
     /// use pubnub::{PubNubClient, Keyset};
     ///
-    /// # use pubnub::core::{Transport, TransportRequest, TransportResponse};
+    /// # use pubnub::core::{Transport, TransportRequest, TransportResponse, PubNubError};
     /// # struct MyTransport;
     /// # #[async_trait::async_trait]
     /// # impl Transport for MyTransport {
-    /// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse,
-    /// pubnub::PubNubError> {
+    /// #     async fn send(&self, _request: TransportRequest) -> Result<TransportResponse, PubNubError> {
     /// #         unimplemented!()
     /// #     }
     /// # }
@@ -435,7 +444,7 @@ where
 #[cfg(test)]
 mod should {
     use super::*;
-    use crate::{TransportRequest, TransportResponse};
+    use crate::core::{TransportRequest, TransportResponse};
     use std::any::type_name;
 
     #[test]

--- a/src/dx/pubnub_client.rs
+++ b/src/dx/pubnub_client.rs
@@ -25,6 +25,9 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 /// and UUID to identify the client.
 ///
 /// [selected]: ../index.html#features
+/// [`Transport`]: ../core/trait.Transport.html
+/// [`Keyset`]: ../core/struct.Keyset.html
+/// [`PubNubClient::builder`]: ./struct.PubNubClient.html#method.builder
 ///
 /// # Examples
 /// ```

--- a/src/dx/pubnub_client.rs
+++ b/src/dx/pubnub_client.rs
@@ -16,18 +16,13 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 
 /// PubNub client
 ///
-/// Client for PubNub API with support for all [selected] PubNub features.
+/// Client for PubNub API with support for all [`selected`] PubNub features.
 /// It is generic over transport layer, which allows to use any transport
 /// that implements [`Transport`] trait.
 ///
 /// Client can be created using [`PubNubClient::builder`] method.
 /// It is required to use [`Keyset`] to provide keys to the client
 /// and UUID to identify the client.
-///
-/// [selected]: ../index.html#features
-/// [`Transport`]: ../core/trait.Transport.html
-/// [`Keyset`]: ../core/struct.Keyset.html
-/// [`PubNubClient::builder`]: ./struct.PubNubClient.html#method.builder
 ///
 /// # Examples
 /// ```
@@ -50,8 +45,6 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 /// ```
 ///
 /// or using own [`Transport`] implementation
-///
-/// [`Transport`]: ../core/trait.Transport.html
 ///
 /// ```
 /// use pubnub::{PubNubClient, Keyset};
@@ -90,6 +83,11 @@ pub(crate) const SDK_ID: &str = "PubNub-Rust";
 /// # See also
 /// [Keyset](struct.Keyset.html)
 /// [Transport](../core/trait.Transport.html)
+///
+/// [`selected`]: ../index.html#features
+/// [`Transport`]: ../core/trait.Transport.html
+/// [`Keyset`]: ../core/struct.Keyset.html
+/// [`PubNubClient::builder`]: ./struct.PubNubClient.html#method.builder
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Builder)]
 #[builder(
     pattern = "owned",
@@ -121,8 +119,6 @@ where
     T: Transport,
 {
     /// Create a new builder for [`PubNubClient`]
-    ///
-    /// [`PubNubClient`]: struct.PubNubClient.html
     ///
     /// # Examples
     /// ```
@@ -158,6 +154,8 @@ where
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// [`PubNubClient`]: struct.PubNubClient.html
     pub fn with_transport(transport: T) -> PubNubClientBuilder<T> {
         PubNubClientBuilder {
             transport: Some(transport),
@@ -319,9 +317,6 @@ where
     /// to set UUID for the client.
     /// See [`Keyset`] for more information.
     ///
-    /// [`PubNubClientUserIdBuilder`]: struct.PubNubClientBuilderKeyset.html
-    /// [`Keyset`]: struct.Keyset.html
-    ///
     /// # Examples
     /// ```
     /// use pubnub::{PubNubClientBuilder, Keyset};
@@ -335,6 +330,9 @@ where
     ///    secret_key: None,
     ///  });
     /// ```
+    ///
+    /// [`PubNubClientUserIdBuilder`]: struct.PubNubClientBuilderKeyset.html
+    /// [`Keyset`]: struct.Keyset.html
     pub fn with_keyset<S>(self, keyset: Keyset<S>) -> PubNubClientUserIdBuilder<T, S>
     where
         S: Into<String>,
@@ -350,9 +348,6 @@ where
 /// It is returned by [`PubNubClientBuilder::with_keyset`]
 /// and provides method to set UUID for the client.
 /// See [`PubNubClient`] for more information.
-///
-/// [`PubNubClient`]: struct.PubNubClient.html
-/// [`PubNubClientBuilder::with_keyset`]: struct.PubNubClientBuilder.html#method.with_keyset
 ///
 /// # Examples
 /// ```
@@ -371,6 +366,9 @@ where
 /// [Keyset](struct.Keyset.html)
 /// [PubNubClientBuilder](struct.PubNubClientBuilder.html)
 /// [PubNubClient](struct.PubNubClient.html)
+///
+/// [`PubNubClient`]: struct.PubNubClient.html
+/// [`PubNubClientBuilder::with_keyset`]: struct.PubNubClientBuilder.html#method.with_keyset
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PubNubClientUserIdBuilder<T, S>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,10 +91,10 @@
 //!
 //! ## Documentation
 //!
-//! :warning: We are under the development! ** Links below not work ** :warning:
+//! :warning: We are under the development! **Links below not work** :warning:
 //!
 //! * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
-//! * [Rust docs](<https://www.docs.rs/pubnub/latest/pubnub>]
+//! * [Rust docs](https://www.docs.rs/pubnub/latest/pubnub)
 //!
 //! ## Support
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,10 @@
 //!
 //! ## Documentation
 //!
-//! * [API reference for Rust](TODO)
+//! :warning: We are under the development! ** Links below not works ** :warning:
+//!
+//! * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
+//! * [Rust docs](https://docs.rs/pubnub/latest/pubnub/]
 //!
 //! ## Support
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //!
 //! ## Documentation
 //!
-//! :warning: We are under the development! ** Links below not works ** :warning:
+//! :warning: We are under the development! ** Links below not work ** :warning:
 //!
 //! * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
 //! * [Rust docs](https://docs.rs/pubnub/latest/pubnub/]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! :warning: We are under the development! ** Links below not work ** :warning:
 //!
 //! * [API reference for Rust](https://www.pubnub.com/docs/sdks/rust)
-//! * [Rust docs](https://docs.rs/pubnub/latest/pubnub/]
+//! * [Rust docs](<https://www.docs.rs/pubnub/latest/pubnub>]
 //!
 //! ## Support
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,18 +104,10 @@
 //! [MIT license]: https://github.com/pubnub/LICENSE/blob/master/LICENSE
 //!
 
-pub use self::core::Transport;
-pub use self::core::TransportRequest;
-pub use self::core::TransportResponse;
-pub use self::core::{PubNubError, Serialize};
-pub mod core;
-
+#[doc(inline)]
 pub use dx::{Keyset, PubNubClient, PubNubClientBuilder};
 pub mod dx;
 
+pub mod core;
 pub mod providers;
-
-#[cfg(feature = "reqwest")]
-pub use transport::reqwest;
-#[cfg(feature = "reqwest")]
 pub mod transport;

--- a/src/providers/serialization_serde.rs
+++ b/src/providers/serialization_serde.rs
@@ -6,7 +6,7 @@
 //!
 //! # Examples
 //! ```
-//! use pubnub::Serialize as _;
+//! use pubnub::core::Serialize as _;
 //! use serde::{Serialize, Deserialize};
 //!
 //! #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -18,18 +18,19 @@
 //! assert_eq!(foo.serialize().unwrap(), b"{\"bar\":\"baz\"}".to_vec());
 //! ```
 
-impl<S> crate::Serialize for S
+impl<S> crate::core::Serialize for S
 where
     S: serde::Serialize,
 {
-    fn serialize(self) -> Result<Vec<u8>, crate::PubNubError> {
-        serde_json::to_vec(&self).map_err(|e| crate::PubNubError::SerializationError(e.to_string()))
+    fn serialize(self) -> Result<Vec<u8>, crate::core::PubNubError> {
+        serde_json::to_vec(&self)
+            .map_err(|e| crate::core::PubNubError::SerializationError(e.to_string()))
     }
 }
 
 #[cfg(test)]
 mod should {
-    use crate::Serialize;
+    use crate::core::Serialize;
 
     #[test]
     fn serialize_serde_values() {

--- a/src/providers/serialization_serde.rs
+++ b/src/providers/serialization_serde.rs
@@ -2,8 +2,6 @@
 //!
 //! This module provides a `serde` serializer for the Pubnub protocol.
 //!
-//! [`Serialize`]: ../trait.Serialize.html
-//!
 //! # Examples
 //! ```
 //! use pubnub::core::Serialize as _;
@@ -17,7 +15,8 @@
 //! let foo = Foo { bar: "baz".to_string() };
 //! assert_eq!(foo.serialize().unwrap(), b"{\"bar\":\"baz\"}".to_vec());
 //! ```
-
+//!
+//! [`Serialize`]: ../trait.Serialize.html
 impl<S> crate::core::Serialize for S
 where
     S: serde::Serialize,

--- a/src/transport/middleware.rs
+++ b/src/transport/middleware.rs
@@ -1,10 +1,26 @@
-//! TODO: docs
+//! PubNub middleware module.
+//!
+//! This module contains the middleware that is used to add the required query parameters to the requests.
+//! The middleware is used to add the `pnsdk`, `uuid`, `instanceid` and `requestid` query parameters to the requests.
 
 use crate::core::{PubNubError, Transport, TransportRequest, TransportResponse};
 use crate::dx::pubnub_client::{SDK_ID, VERSION};
 use uuid::Uuid;
 
-/// TODO: Add docs
+/// PubNub middleware.
+///
+/// This middleware is used to add the required query parameters to the requests.
+/// The middleware is used to add the `pnsdk`, `uuid`, `instanceid` and `requestid` query parameters to the requests.
+///
+/// The `pnsdk` query parameter is used to identify the SDK that is used to make the request.
+/// The `uuid` query parameter is used to identify the user that is making the request.
+/// The `instanceid` query parameter is used to identify the instance of the SDK that is making the request.
+/// The `requestid` query parameter is used to identify the request that is being made.
+///
+/// It is used internally by the [`PubNubClient`].
+/// If you are using the [`PubNubClient`] you don't need to use this middleware.
+///
+/// [`PubNubClient`]: crate::dx::PubNubClient
 pub struct PubNubMiddleware<T>
 where
     T: Transport + Send + Sync,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -9,6 +9,7 @@
 pub mod middleware;
 
 #[cfg(feature = "reqwest")]
+#[doc(inline)]
 pub use self::reqwest::TransportReqwest;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;

--- a/src/transport/reqwest.rs
+++ b/src/transport/reqwest.rs
@@ -42,7 +42,7 @@ pub struct TransportReqwest {
     /// It defaults to `https://ps.pndsn.com/`.
     /// # Examples
     /// ```
-    /// use pubnub::reqwest::TransportReqwest;
+    /// use pubnub::transport::TransportReqwest;
     ///
     /// let transport = {
     ///    let mut transport = TransportReqwest::default();
@@ -107,7 +107,7 @@ impl TransportReqwest {
     ///
     /// # Example
     /// ```
-    /// use pubnub::reqwest::TransportReqwest;
+    /// use pubnub::transport::TransportReqwest;
     ///
     /// let transport = TransportReqwest::new();
     /// ```

--- a/src/transport/reqwest.rs
+++ b/src/transport/reqwest.rs
@@ -99,18 +99,18 @@ impl TransportReqwest {
     /// It provides a default [`reqwest`] client using [`reqwest::Client::default()`]
     /// and a default hostname of `https://ps.pndsn.com`.
     ///
-    /// [`TransportReqwest`]: ./struct.TransportReqwest.html
-    /// [`PubNubClient`]: ../pubnub_client/struct.PubNubClient.html
-    /// [`pubnub`]: ../index.html
-    /// [`PubNubClientBuilder`]: ../pubnub_client/struct.PubNubClientBuilder.html
-    /// [`reqwest`]: https://docs.rs/reqwest
-    ///
     /// # Example
     /// ```
     /// use pubnub::transport::TransportReqwest;
     ///
     /// let transport = TransportReqwest::new();
     /// ```
+    ///
+    /// [`TransportReqwest`]: ./struct.TransportReqwest.html
+    /// [`PubNubClient`]: ../pubnub_client/struct.PubNubClient.html
+    /// [`pubnub`]: ../index.html
+    /// [`PubNubClientBuilder`]: ../pubnub_client/struct.PubNubClientBuilder.html
+    /// [`reqwest`]: https://docs.rs/reqwest
     pub fn new() -> Self {
         Self::default()
     }
@@ -162,12 +162,6 @@ impl PubNubClientBuilder<TransportReqwest> {
     /// The default hostname is `https://ps.pndsn.com`.
     /// The default [`reqwest`] client is created using [`reqwest::Client::default()`].
     ///
-    /// [`PubNubClientBuilder`]: ../pubnub_client/struct.PubNubClientBuilder.html
-    /// [`TransportReqwest`]: ./struct.TransportReqwest.html
-    /// [`reqwest`]: https://docs.rs/reqwest
-    /// [`PubNub API`]: https://www.pubnub.com/docs
-    /// [`PubNubClient`]: ../pubnub_client/struct.PubNubClient.html
-    ///
     /// # Examples
     /// ```
     /// use pubnub::{PubNubClientBuilder, Keyset};
@@ -181,6 +175,12 @@ impl PubNubClientBuilder<TransportReqwest> {
     ///     .with_user_id("user-123")
     ///     .build();
     /// ```
+    ///
+    /// [`PubNubClientBuilder`]: ../pubnub_client/struct.PubNubClientBuilder.html
+    /// [`TransportReqwest`]: ./struct.TransportReqwest.html
+    /// [`reqwest`]: https://docs.rs/reqwest
+    /// [`PubNub API`]: https://www.pubnub.com/docs
+    /// [`PubNubClient`]: ../pubnub_client/struct.PubNubClient.html
     pub fn with_reqwest_transport() -> PubNubClientBuilder<TransportReqwest> {
         PubNubClientBuilder {
             transport: Some(TransportReqwest::new()),


### PR DESCRIPTION
I removed every `TODO: <docs related>` comments. Additionally, all the documentation warnings has been fixed. 
There is also a little change in the docs and modules structure but everything has been adjusted so everything compiles and all tests are passing.