### PR TITLE
Add signature when secret key is present

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ thiserror = "1.0"
 log = "0.4"
 uuid = { version = "1.3", features = ["v4"] }
 urlencoding = "2.1.2"
+hmac = "0.12"
+sha2 = "0.10"
+base64 = "0.21"
 
 # serde
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/transport/middleware.rs
+++ b/src/transport/middleware.rs
@@ -3,8 +3,14 @@
 //! This module contains the middleware that is used to add the required query parameters to the requests.
 //! The middleware is used to add the `pnsdk`, `uuid`, `instanceid` and `requestid` query parameters to the requests.
 
-use crate::core::{PubNubError, Transport, TransportRequest, TransportResponse};
+use crate::core::{PubNubError, Transport, TransportMethod, TransportRequest, TransportResponse};
 use crate::dx::pubnub_client::{SDK_ID, VERSION};
+use base64::{engine::general_purpose, Engine as _};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use urlencoding::encode;
 use uuid::Uuid;
 
 /// PubNub middleware.
@@ -28,6 +34,71 @@ where
     pub(crate) transport: T,
     pub(crate) instance_id: Option<String>,
     pub(crate) user_id: String,
+    pub(crate) signature_keys: Option<SignatureKeySet>,
+}
+
+pub(crate) struct SignatureKeySet {
+    pub(crate) secret_key: String,
+    pub(crate) publish_key: String,
+    pub(crate) subscribe_key: String,
+}
+
+impl SignatureKeySet {
+    fn handle_query_params(query_parameters: &HashMap<String, String>) -> String {
+        let mut query_params_str = query_parameters
+            .iter()
+            .map(|(key, value)| format!("{}={}", key, encode(value)))
+            .collect::<Vec<String>>();
+        query_params_str.sort_unstable();
+        query_params_str.join("&")
+    }
+
+    fn prepare_signature_v1_input(&self, req: &TransportRequest) -> String {
+        let mut signature_input = String::new();
+        signature_input.push_str(self.subscribe_key.as_str());
+        signature_input.push('\n');
+        signature_input.push_str(self.publish_key.as_str());
+        signature_input.push('\n');
+        signature_input.push_str(req.path.as_str());
+        signature_input.push('\n');
+        signature_input
+            .push_str(SignatureKeySet::handle_query_params(&req.query_parameters).as_str());
+        signature_input
+    }
+
+    fn prepare_signature_v2_input_without_body(&self, req: &TransportRequest) -> String {
+        let mut signature_input = String::new();
+        signature_input.push_str(req.method.to_string().to_ascii_uppercase().as_str());
+        signature_input.push('\n');
+        signature_input.push_str(self.publish_key.as_str());
+        signature_input.push('\n');
+        signature_input.push_str(req.path.as_str());
+        signature_input.push('\n');
+        signature_input
+            .push_str(SignatureKeySet::handle_query_params(&req.query_parameters).as_str());
+        signature_input.push('\n');
+        signature_input
+    }
+
+    fn calculate_signature(&self, req: &TransportRequest) -> String {
+        let mut mac = Hmac::<Sha256>::new_from_slice(self.secret_key.as_bytes())
+            .expect("HMAC can take key of any size");
+        if req.method == TransportMethod::Post && req.path.starts_with("/publish") {
+            let input = self.prepare_signature_v1_input(req);
+            mac.update(input.as_bytes());
+            let result = mac.finalize();
+            general_purpose::URL_SAFE_NO_PAD.encode(result.into_bytes())
+        } else {
+            let input = self.prepare_signature_v2_input_without_body(req);
+            mac.update(input.as_bytes());
+            mac.update(req.body.as_deref().unwrap_or_default());
+            let result = mac.finalize();
+            format!(
+                "v2.{}",
+                general_purpose::URL_SAFE_NO_PAD.encode(result.into_bytes())
+            )
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -48,6 +119,21 @@ where
                 .insert("instanceid".into(), instance_id.clone());
         }
 
+        if let Some(signature_key_set) = &self.signature_keys {
+            req.query_parameters.insert(
+                "timestamp".into(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| PubNubError::TransportError(e.to_string()))?
+                    .as_secs()
+                    .to_string(),
+            );
+            req.query_parameters.insert(
+                "signature".into(),
+                signature_key_set.calculate_signature(&req),
+            );
+        }
+
         self.transport.send(req).await
     }
 }
@@ -55,7 +141,9 @@ where
 #[cfg(test)]
 mod should {
     use super::*;
+    use crate::core::TransportMethod::Get;
     use crate::core::TransportResponse;
+    use std::collections::HashMap;
 
     #[tokio::test]
     async fn publish_message() {
@@ -89,10 +177,36 @@ mod should {
             transport: MockTransport::default(),
             instance_id: Some(String::from("instance_id")),
             user_id: "user_id".to_string(),
+            signature_keys: None,
         };
 
         let result = middleware.send(TransportRequest::default()).await;
 
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_signature() {
+        let signature_key_set = SignatureKeySet {
+            secret_key: "secKey".into(),
+            publish_key: "pubKey".into(),
+            subscribe_key: "".into(),
+        };
+
+        let request = TransportRequest {
+            path: "/publish/pubKey/subKey/0/my_channel/0/%22hello%21%22".to_string(),
+            method: Get,
+            body: None,
+            query_parameters: HashMap::from([
+                ("store".to_string(), "1".to_string()),
+                ("ttl".to_string(), "10".to_string()),
+                ("uuid".to_string(), "userId".to_string()),
+                ("pnsdk".to_string(), "PubNub-Rust".to_string()),
+                ("timestamp".to_string(), "1679642098".to_string()),
+            ]),
+            ..TransportRequest::default()
+        };
+        let signature = signature_key_set.calculate_signature(&request);
+        assert_eq!("v2.AHl5lMpzyT4qcvvlqaszCjTUqU6dPb10a4_XSaYCNIQ", signature);
     }
 }


### PR DESCRIPTION
When publishing with POST signature need to be a v1 signature. Every other call should be signed with v2 signature. In case of providing secret key but not providing publish the initialization of client will result in error.