### PR TITLE
Exclude `.release` folder from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ target
 Cargo.lock
 tests/features
 tests/reports
+
+# GitHub Actions #
+##################
+.github/.release


### PR DESCRIPTION
build(github-action): exclude `.release` folder from `.gitignore`

`cargo publish` doesn't like the idea of having custom action files cloned into the working directory and not committed.