### PR TITLE
Fix `cursor` reset issue and cancelled `effects` spawning

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,28 @@
 name: rust
-version: 0.5.0
+version: 0.6.0
 schema: 1
 scm: github.com/pubnub/rust
 files: []
 changelog:
+  - date: 2024-02-07
+    version: 0.6.0
+    changes:
+      - type: feature
+        text: "Make it possible to create `SubscriptionCursor` from the string slice."
+      - type: feature
+        text: "Add `add_subscriptions(..)` and `sub_subscriptions(..)` to `SubscriptionSet` to make it possible in addition to sets manipulation use list of subscriptions."
+      - type: bug
+        text: "Fix issue because of which `cursor` is not reset on `Subscription` and `SubscriptionSet` on unsubscribe."
+      - type: bug
+        text: "Fix issue because of which cancelled effects still asynchronously spawned for processing."
+      - type: improvement
+        text: "Change `client` to `pubnub` in inline docs."
+      - type: improvement
+        text: "Add subscription token validation."
+      - type: improvement
+        text: "Added a method to validate the provided subscription token to conform to PubNub time token requirements with precision."
+      - type: improvement
+        text: "Separate `subscribe` example into two to show separately `subscribe` feature and `presence state` maintenance with subscribe."
   - date: 2024-01-25
     version: 0.5.0
     changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubnub"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license-file = "LICENSE"
 authors = ["PubNub <support@pubnub.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,10 @@ required-features = ["default"]
 
 [[example]]
 name = "subscribe"
+required-features = ["default", "subscribe"]
+
+[[example]]
+name = "subscribe_with_presence_state"
 required-features = ["default", "subscribe", "presence"]
 
 [[example]]

--- a/examples/subscribe.rs
+++ b/examples/subscribe.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn snafu::Error>> {
         channel_groups: None,
         options: Some(vec![SubscriptionOptions::ReceivePresenceEvents]),
     });
-    subscription.subscribe(None);
+    subscription.subscribe();
     let subscription_clone = subscription.clone_empty();
 
     // Attach connection status to the PubNub client instance.
@@ -130,7 +130,9 @@ async fn main() -> Result<(), Box<dyn snafu::Error>> {
     // drop(subscription_clone);
 
     println!(
-        "\nUnsubscribe from all data streams. To restore requires `subscription.subscribe(None)` call." );
+        "\nUnsubscribe from all data streams. To restore call `subscription.subscribe()` or \
+        `subscription.subscribe_with_timetoken(Some(<timetoken>)) call."
+    );
     // Clean up before complete work with PubNub client instance.
     pubnub.unsubscribe_all();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;

--- a/examples/subscribe_with_presence_state.rs
+++ b/examples/subscribe_with_presence_state.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn snafu::Error>> {
         channel_groups: None,
         options: Some(vec![SubscriptionOptions::ReceivePresenceEvents]),
     });
-    subscription.subscribe(None);
+    subscription.subscribe();
     let subscription_clone = subscription.clone_empty();
 
     // Attach connection status to the PubNub client instance.
@@ -145,7 +145,9 @@ async fn main() -> Result<(), Box<dyn snafu::Error>> {
     // drop(subscription_clone);
 
     println!(
-        "\nUnsubscribe from all data streams. To restore requires `subscription.subscribe(None)` call." );
+        "\nUnsubscribe from all data streams. To restore call `subscription.subscribe()` or \
+        `subscription.subscribe_with_timetoken(Some(<timetoken>)) call."
+    );
     // Clean up before complete work with PubNub client instance.
     pubnub.unsubscribe_all();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;

--- a/src/core/event_engine/effect.rs
+++ b/src/core/event_engine/effect.rs
@@ -18,4 +18,14 @@ pub(crate) trait Effect: Send + Sync {
 
     /// Cancel any ongoing effect's work.
     fn cancel(&self);
+
+    /// Check whether effect has been cancelled.
+    ///
+    /// Event engine dispatch effects asynchronously and there is a chance that
+    /// effect already has been cancelled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if effect has been cancelled.   
+    fn is_cancelled(&self) -> bool;
 }

--- a/src/core/event_engine/effect_dispatcher.rs
+++ b/src/core/event_engine/effect_dispatcher.rs
@@ -85,6 +85,11 @@ where
                             let cloned_self = cloned_self.clone();
 
                             runtime_clone.spawn(async move {
+                                // There is no need to spawn effect which already has been
+                                // cancelled.
+                                if effect.is_cancelled() {
+                                    return;
+                                }
                                 let events = effect.run().await;
 
                                 if invocation.is_managed() {
@@ -196,6 +201,10 @@ mod should {
 
         fn cancel(&self) {
             // Do nothing.
+        }
+
+        fn is_cancelled(&self) -> bool {
+            false
         }
     }
 

--- a/src/core/event_engine/mod.rs
+++ b/src/core/event_engine/mod.rs
@@ -314,6 +314,10 @@ mod should {
         fn cancel(&self) {
             // Do nothing.
         }
+
+        fn is_cancelled(&self) -> bool {
+            false
+        }
     }
 
     enum TestInvocation {

--- a/src/dx/presence/event_engine/effect_handler.rs
+++ b/src/dx/presence/event_engine/effect_handler.rs
@@ -4,6 +4,7 @@
 //! event engine for
 
 use async_channel::Sender;
+use spin::RwLock;
 use uuid::Uuid;
 
 use crate::{
@@ -77,6 +78,7 @@ impl EffectHandler<PresenceEffectInvocation, PresenceEffect> for PresenceEffectH
                 reason,
             } => Some(PresenceEffect::DelayedHeartbeat {
                 id: Uuid::new_v4().to_string(),
+                cancelled: RwLock::new(false),
                 input: input.clone(),
                 attempts: *attempts,
                 reason: reason.clone(),
@@ -91,6 +93,7 @@ impl EffectHandler<PresenceEffectInvocation, PresenceEffect> for PresenceEffectH
             }),
             PresenceEffectInvocation::Wait { input } => Some(PresenceEffect::Wait {
                 id: Uuid::new_v4().to_string(),
+                cancelled: RwLock::new(false),
                 input: input.clone(),
                 executor: self.wait_call.clone(),
                 cancellation_channel: self.cancellation_channel.clone(),

--- a/src/dx/pubnub_client.rs
+++ b/src/dx/pubnub_client.rs
@@ -76,7 +76,7 @@ use crate::{
 /// // note that `with_reqwest_transport` requires `reqwest` feature
 /// // to be enabled (default)
 /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-/// let client = PubNubClientBuilder::with_reqwest_transport()
+/// let pubnub = PubNubClientBuilder::with_reqwest_transport()
 ///    .with_keyset(Keyset {
 ///         publish_key: Some("pub-c-abc123"),
 ///         subscribe_key: "sub-c-abc123",
@@ -112,7 +112,7 @@ use crate::{
 /// // note that MyTransport must implement the `Transport` trait
 /// let transport = MyTransport::new();
 ///
-/// let client = PubNubClientBuilder::with_transport(MyTransport)
+/// let pubnub = PubNubClientBuilder::with_transport(MyTransport)
 ///    .with_keyset(Keyset {
 ///         publish_key: Some("pub-c-abc123"),
 ///         subscribe_key: "sub-c-abc123",
@@ -161,7 +161,7 @@ pub type PubNubGenericClient<T, D> = PubNubClientInstance<PubNubMiddleware<T>, D
 /// // note that `with_reqwest_transport` requires `reqwest` feature
 /// // to be enabled (default)
 /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-/// let client = PubNubClientBuilder::with_reqwest_transport()
+/// let pubnub = PubNubClientBuilder::with_reqwest_transport()
 ///    .with_keyset(Keyset {
 ///         publish_key: Some("pub-c-abc123"),
 ///         subscribe_key: "sub-c-abc123",
@@ -197,7 +197,7 @@ pub type PubNubGenericClient<T, D> = PubNubClientInstance<PubNubMiddleware<T>, D
 /// // note that MyTransport must implement the `Transport` trait
 /// let transport = MyTransport::new();
 ///
-/// let client = PubNubClientBuilder::with_transport(MyTransport)
+/// let pubnub = PubNubClientBuilder::with_transport(MyTransport)
 ///    .with_keyset(Keyset {
 ///         publish_key: Some("pub-c-abc123"),
 ///         subscribe_key: "sub-c-abc123",
@@ -417,7 +417,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -426,7 +426,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channel = client.channel("my_channel");
+    /// let channel = pubnub.channel("my_channel");
     /// #     Ok(())
     /// # }
     /// ```
@@ -464,7 +464,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -473,7 +473,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channel = client.channels(&["my_channel_1", "my_channel_2"]);
+    /// let channels = pubnub.channels(&["my_channel_1", "my_channel_2"]);
     /// #     Ok(())
     /// # }
     /// ```
@@ -517,7 +517,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -526,7 +526,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channel_group = client.channel_group("my_group");
+    /// let channel_group = pubnub.channel_group("my_group");
     /// #     Ok(())
     /// # }
     /// ```
@@ -565,7 +565,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -574,7 +574,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channel_groups = client.channel_groups(&["my_group_1", "my_group_2"]);
+    /// let channel_groups = pubnub.channel_groups(&["my_group_1", "my_group_2"]);
     /// #     Ok(())
     /// # }
     /// ```
@@ -620,7 +620,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -629,7 +629,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channel_metadata = client.channel_metadata("channel_meta");
+    /// let channel_metadata = pubnub.channel_metadata("channel_meta");
     /// #     Ok(())
     /// # }
     /// ```
@@ -670,7 +670,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -679,7 +679,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channels_metadata = client.channels_metadata(
+    /// let channels_metadata = pubnub.channels_metadata(
     ///     &["channel_meta_1", "channel_meta_2"]
     /// );
     /// #     Ok(())
@@ -727,7 +727,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -736,7 +736,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let user_metadata = client.user_metadata("user_meta");
+    /// let user_metadata = pubnub.user_metadata("user_meta");
     /// #     Ok(())
     /// # }
     /// ```
@@ -776,7 +776,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -785,7 +785,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let users_metadata = client.users_metadata(&["user_meta_1", "user_meta_2"]);
+    /// let users_metadata = pubnub.users_metadata(&["user_meta_1", "user_meta_2"]);
     /// #     Ok(())
     /// # }
     /// ```
@@ -823,7 +823,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
     /// let token = "<auth token from grant_token>";
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -832,7 +832,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// client.set_token(token);
+    /// pubnub.set_token(token);
     /// // Now client has access to all endpoints for which `token` has
     /// // permissions.
     /// #     Ok(())
@@ -854,7 +854,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     ///
     /// # fn main() -> Result<(), pubnub::core::PubNubError> {
     /// #     let token = "<auth token from grant_token>";
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -863,8 +863,8 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// #     client.set_token(token);
-    /// println!("Current authentication token: {:?}", client.get_token());
+    /// #     pubnub.set_token(token);
+    /// println!("Current authentication token: {:?}", pubnub.get_token());
     /// // Now client has access to all endpoints for which `token` has
     /// // permissions.
     /// #     Ok(())
@@ -1293,7 +1293,7 @@ impl PubNubClientBuilder {
     /// // note that MyTransport must implement the `Transport` trait
     /// let transport = MyTransport::new();
     ///
-    /// let client = PubNubClientBuilder::with_transport(transport)
+    /// let pubnub = PubNubClientBuilder::with_transport(transport)
     ///     .with_keyset(Keyset {
     ///         publish_key: Some("pub-c-abc123"),
     ///         subscribe_key: "sub-c-abc123",
@@ -1343,7 +1343,7 @@ impl PubNubClientBuilder {
     /// // note that MyTransport must implement the `Transport` trait
     /// let transport = MyTransport::new();
     ///
-    /// let client = PubNubClientBuilder::with_transport(transport)
+    /// let pubnub = PubNubClientBuilder::with_transport(transport)
     ///     .with_keyset(Keyset {
     ///         publish_key: Some("pub-c-abc123"),
     ///         subscribe_key: "sub-c-abc123",
@@ -1392,7 +1392,7 @@ impl PubNubClientBuilder {
     /// // note that MyTransport must implement the `Transport` trait
     /// let transport = MyTransport::new();
     ///
-    /// let client = PubNubClientBuilder::with_blocking_transport(transport)
+    /// let pubnub = PubNubClientBuilder::with_blocking_transport(transport)
     ///     .with_keyset(Keyset {
     ///         publish_key: Some("pub-c-abc123"),
     ///         subscribe_key: "sub-c-abc123",
@@ -1445,7 +1445,7 @@ impl PubNubClientBuilder {
     /// // note that MyTransport must implement the `Transport` trait
     /// let transport = MyTransport::new();
     ///
-    /// let client = PubNubClientBuilder::with_blocking_transport(transport)
+    /// let pubnub = PubNubClientBuilder::with_blocking_transport(transport)
     ///     .with_keyset(Keyset {
     ///         publish_key: Some("pub-c-abc123"),
     ///         subscribe_key: "sub-c-abc123",
@@ -1591,7 +1591,7 @@ impl<T> PubNubClientRuntimeBuilder<T> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// // note that with_reqwest_transport is only available when
     /// // the `reqwest` feature is enabled (default)
-    /// let client = PubNubClientBuilder::with_reqwest_transport()
+    /// let pubnub = PubNubClientBuilder::with_reqwest_transport()
     ///     .with_runtime(MyRuntime)
     ///     .with_keyset(Keyset {
     ///         subscribe_key: "sub-c-abc123",
@@ -1653,7 +1653,7 @@ impl<T> PubNubClientRuntimeBuilder<T> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// // note that with_reqwest_transport is only available when
     /// // the `reqwest` feature is enabled (default)
-    /// let client = PubNubClientBuilder::with_reqwest_transport()
+    /// let pubnub = PubNubClientBuilder::with_reqwest_transport()
     ///     .with_runtime(MyRuntime)
     ///     .with_keyset(Keyset {
     ///         subscribe_key: "sub-c-abc123",

--- a/src/dx/subscribe/event_dispatcher.rs
+++ b/src/dx/subscribe/event_dispatcher.rs
@@ -1,7 +1,7 @@
 //! # Event dispatcher module
 //!
 //! This module contains the [`EventDispatcher`] type, which is used by
-//! [`PubNubClientInstance`], [`Subscription2`] and [`SubscriptionSet`] to let
+//! [`PubNubClientInstance`], [`Subscription`] and [`SubscriptionSet`] to let
 //! users attach listeners to the specific event types.
 
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/src/dx/subscribe/event_engine/effect_handler.rs
+++ b/src/dx/subscribe/event_engine/effect_handler.rs
@@ -1,4 +1,5 @@
 use async_channel::Sender;
+use spin::rwlock::RwLock;
 use uuid::Uuid;
 
 use crate::core::RequestRetryConfiguration;
@@ -60,6 +61,7 @@ impl EffectHandler<SubscribeEffectInvocation, SubscribeEffect> for SubscribeEffe
             SubscribeEffectInvocation::Handshake { input, cursor } => {
                 Some(SubscribeEffect::Handshake {
                     id: Uuid::new_v4().to_string(),
+                    cancelled: RwLock::new(false),
                     input: input.clone(),
                     cursor: cursor.clone(),
                     executor: self.subscribe_call.clone(),
@@ -73,6 +75,7 @@ impl EffectHandler<SubscribeEffectInvocation, SubscribeEffect> for SubscribeEffe
                 reason,
             } => Some(SubscribeEffect::HandshakeReconnect {
                 id: Uuid::new_v4().to_string(),
+                cancelled: RwLock::new(false),
                 input: input.clone(),
                 cursor: cursor.clone(),
                 attempts: *attempts,
@@ -84,6 +87,7 @@ impl EffectHandler<SubscribeEffectInvocation, SubscribeEffect> for SubscribeEffe
             SubscribeEffectInvocation::Receive { input, cursor } => {
                 Some(SubscribeEffect::Receive {
                     id: Uuid::new_v4().to_string(),
+                    cancelled: RwLock::new(false),
                     input: input.clone(),
                     cursor: cursor.clone(),
                     executor: self.subscribe_call.clone(),
@@ -97,6 +101,7 @@ impl EffectHandler<SubscribeEffectInvocation, SubscribeEffect> for SubscribeEffe
                 reason,
             } => Some(SubscribeEffect::ReceiveReconnect {
                 id: Uuid::new_v4().to_string(),
+                cancelled: RwLock::new(false),
                 input: input.clone(),
                 cursor: cursor.clone(),
                 attempts: *attempts,

--- a/src/dx/subscribe/event_engine/effects/receive.rs
+++ b/src/dx/subscribe/event_engine/effects/receive.rs
@@ -128,4 +128,23 @@ mod should {
             SubscribeEvent::ReceiveFailure { .. }
         ));
     }
+
+    #[tokio::test]
+    async fn return_empty_event_on_effect_cancel_err() {
+        let mock_receive_function: Arc<SubscribeEffectExecutor> =
+            Arc::new(move |_| async move { Err(PubNubError::EffectCanceled) }.boxed());
+
+        let result = execute(
+            &SubscriptionInput::new(
+                &Some(vec!["ch1".to_string()]),
+                &Some(vec!["cg1".to_string()]),
+            ),
+            &Default::default(),
+            "id",
+            &mock_receive_function,
+        )
+        .await;
+
+        assert!(result.is_empty());
+    }
 }

--- a/src/dx/subscribe/event_engine/state.rs
+++ b/src/dx/subscribe/event_engine/state.rs
@@ -231,7 +231,10 @@ impl SubscribeState {
                         input: SubscriptionInput::new(channels, channel_groups),
                         cursor: cursor.clone(),
                     }),
-                    None,
+                    Some(vec![EmitStatus(ConnectionStatus::SubscriptionChanged {
+                        channels: channels.clone(),
+                        channel_groups: channel_groups.clone(),
+                    })]),
                 ))
             }
             Self::ReceiveFailed { cursor, .. } => Some(self.transition_to(
@@ -290,7 +293,10 @@ impl SubscribeState {
                     input: SubscriptionInput::new(channels, channel_groups),
                     cursor: restore_cursor.clone(),
                 }),
-                None,
+                Some(vec![EmitStatus(ConnectionStatus::SubscriptionChanged {
+                    channels: channels.clone(),
+                    channel_groups: channel_groups.clone(),
+                })]),
             )),
             Self::ReceiveFailed { .. } => Some(self.transition_to(
                 Some(Self::Handshaking {

--- a/src/dx/subscribe/mod.rs
+++ b/src/dx/subscribe/mod.rs
@@ -371,6 +371,7 @@ where
     pub fn reconnect(&self, cursor: Option<SubscriptionCursor>) {
         #[cfg(feature = "presence")]
         let mut input: Option<SubscriptionInput> = None;
+        let cursor = cursor.or_else(|| self.cursor.read().clone());
 
         if let Some(manager) = self.subscription_manager(false).read().as_ref() {
             #[cfg(feature = "presence")]
@@ -411,6 +412,9 @@ where
     /// created [`Subscription`] and [`SubscriptionSet`].
     pub fn unsubscribe_all(&self) {
         {
+            let mut cursor = self.cursor.write();
+            *cursor = None;
+
             if let Some(manager) = self.subscription_manager(false).write().as_mut() {
                 manager.unregister_all()
             }

--- a/src/dx/subscribe/mod.rs
+++ b/src/dx/subscribe/mod.rs
@@ -148,7 +148,7 @@ where
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -160,8 +160,8 @@ where
     /// // ...
     /// // We need to pass client into other component which would like to
     /// // have own listeners to handle real-time events.
-    /// let empty_client = client.clone_empty();
-    /// // self.other_component(empty_client);    
+    /// let empty_pubnub_client = pubnub.clone_empty();
+    /// // self.other_component(empty_pubnub_client);    
     /// #     Ok(())
     /// # }
     /// ```
@@ -199,12 +199,16 @@ where
     ///
     /// ```rust,no_run
     /// use futures::StreamExt;
-    /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset, subscribe::EventEmitter};
+    /// use pubnub::{
+    ///     subscribe::{
+    ///         EventEmitter, {EventSubscriber, SubscriptionParams},
+    ///     },
+    ///     Keyset, PubNubClient, PubNubClientBuilder,
+    /// };
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// use pubnub::subscribe::{EventSubscriber, SubscriptionParams};
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -213,7 +217,7 @@ where
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let subscription = client.subscription(SubscriptionParams {
+    /// let subscription = pubnub.subscription(SubscriptionParams {
     ///     channels: Some(&["my_channel_1", "my_channel_2", "my_channel_3"]),
     ///     channel_groups: None,
     ///     options: None
@@ -257,14 +261,16 @@ where
     ///
     /// ```no_run
     /// use futures::StreamExt;
-    /// use pubnub::dx::subscribe::{EventEmitter, SubscribeStreamEvent, Update};
+    /// use pubnub::{
+    ///     subscribe::{
+    ///         EventEmitter, {EventSubscriber, SubscriptionParams, Update},
+    ///     },
+    ///     Keyset, PubNubClient, PubNubClientBuilder,
+    /// };
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     use pubnub::{Keyset, PubNubClientBuilder};
-    /// use pubnub::subscribe::SubscriptionParams;
-    /// #
-    /// #     let client = PubNubClientBuilder::with_reqwest_transport()
+    /// #     let pubnub = PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #             subscribe_key: "demo",
     /// #             publish_key: Some("demo"),
@@ -272,14 +278,14 @@ where
     /// #         })
     /// #         .with_user_id("user_id")
     /// #         .build()?;
-    /// # let subscription = client.subscription(SubscriptionParams {
+    /// # let subscription = pubnub.subscription(SubscriptionParams {
     /// #     channels: Some(&["channel"]),
     /// #     channel_groups: None,
     /// #     options: None
     /// # });
     /// # let stream = // DataStream<Message>
     /// #     subscription.messages_stream();
-    /// client.disconnect();
+    /// pubnub.disconnect();
     /// # Ok(())
     /// # }
     /// ```
@@ -330,14 +336,16 @@ where
     ///
     /// ```no_run
     /// use futures::StreamExt;
-    /// use pubnub::dx::subscribe::{EventEmitter, SubscribeStreamEvent, Update};
+    /// use pubnub::{
+    ///     subscribe::{
+    ///         EventEmitter, {EventSubscriber, SubscriptionParams, Update},
+    ///     },
+    ///     Keyset, PubNubClient, PubNubClientBuilder,
+    /// };
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// #     use pubnub::{Keyset, PubNubClientBuilder};
-    /// use pubnub::subscribe::SubscriptionParams;
-    /// #
-    /// #     let client = PubNubClientBuilder::with_reqwest_transport()
+    /// #     let pubnub = PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #             subscribe_key: "demo",
     /// #             publish_key: Some("demo"),
@@ -345,7 +353,7 @@ where
     /// #         })
     /// #         .with_user_id("user_id")
     /// #         .build()?;
-    /// # let subscription = client.subscription(SubscriptionParams {
+    /// # let subscription = pubnub.subscription(SubscriptionParams {
     /// #     channels: Some(&["channel"]),
     /// #     channel_groups: None,
     /// #     options: None
@@ -353,8 +361,8 @@ where
     /// # let stream = // DataStream<Message>
     /// #     subscription.messages_stream();
     /// # // .....
-    /// # client.disconnect();
-    /// client.reconnect(None);
+    /// # pubnub.disconnect();
+    /// pubnub.reconnect(None);
     /// # Ok(())
     /// # }
     /// ```
@@ -624,13 +632,16 @@ impl<T, D> PubNubClientInstance<T, D> {
     ///
     /// ```no_run // Starts listening for real-time updates
     /// use futures::StreamExt;
-    /// use pubnub::dx::subscribe::{SubscribeStreamEvent, Update};
+    /// use pubnub::{
+    ///     subscribe::{
+    ///         EventEmitter, {EventSubscriber, SubscriptionParams, Update},
+    ///     },
+    ///     Keyset, PubNubClient, PubNubClientBuilder,
+    /// };
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use pubnub::{Keyset, PubNubClientBuilder};
-    /// #
-    /// #   let client = PubNubClientBuilder::with_reqwest_transport()
+    /// #   let pubnub = PubNubClientBuilder::with_reqwest_transport()
     /// #      .with_keyset(Keyset {
     /// #          subscribe_key: "demo",
     /// #          publish_key: Some("demo"),
@@ -638,7 +649,7 @@ impl<T, D> PubNubClientInstance<T, D> {
     /// #      })
     /// #      .with_user_id("user_id")
     /// #      .build()?;
-    /// client
+    /// pubnub
     ///     .subscribe_raw()
     ///     .channels(["hello".into(), "world".into()].to_vec())
     ///     .execute()?

--- a/src/dx/subscribe/mod.rs
+++ b/src/dx/subscribe/mod.rs
@@ -915,7 +915,7 @@ mod should {
             channel_groups: Some(&["group_a"]),
             options: Some(vec![SubscriptionOptions::ReceivePresenceEvents]),
         });
-        subscription.subscribe(None);
+        subscription.subscribe();
 
         let status = client.status_stream().next().await.unwrap();
         let _ = subscription.messages_stream().next().await.unwrap();

--- a/src/dx/subscribe/subscription.rs
+++ b/src/dx/subscribe/subscription.rs
@@ -44,7 +44,7 @@ use crate::{
 /// };
 ///
 /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-/// let client = // PubNubClient
+/// let pubnub = // PubNubClient
 /// #     PubNubClientBuilder::with_reqwest_transport()
 /// #         .with_keyset(Keyset {
 /// #              subscribe_key: "demo",
@@ -53,7 +53,7 @@ use crate::{
 /// #          })
 /// #         .with_user_id("uuid")
 /// #         .build()?;
-/// let channel = client.channel("my_channel");
+/// let channel = pubnub.channel("my_channel");
 /// // Creating Subscription instance for the Channel entity to subscribe and listen
 /// // for real-time events.
 /// let subscription = channel.subscription(None);
@@ -72,7 +72,7 @@ use crate::{
 /// };
 ///
 /// # fn main() -> Result<(), pubnub::core::PubNubError> {
-/// let client = // PubNubClient
+/// let pubnub = // PubNubClient
 /// #     PubNubClientBuilder::with_reqwest_transport()
 /// #         .with_keyset(Keyset {
 /// #              subscribe_key: "demo",
@@ -81,7 +81,7 @@ use crate::{
 /// #          })
 /// #         .with_user_id("uuid")
 /// #         .build()?;
-/// let channels = client.channels(&["my_channel_1", "my_channel_2"]);
+/// let channels = pubnub.channels(&["my_channel_1", "my_channel_2"]);
 /// // Two `Subscription` instances can be added to create `SubscriptionSet` which can be used
 /// // to attach listeners and subscribe in one place for both subscriptions used in addition
 /// // operation.
@@ -206,7 +206,7 @@ where
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -215,7 +215,7 @@ where
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let channel = client.channel("my_channel");
+    /// let channel = pubnub.channel("my_channel");
     /// // Creating Subscription instance for the Channel entity to subscribe and listen
     /// // for real-time events.
     /// let subscription = channel.subscription(None);

--- a/src/dx/subscribe/subscription.rs
+++ b/src/dx/subscribe/subscription.rs
@@ -521,6 +521,9 @@ where
                 return;
             }
             *is_subscribed_slot = false;
+
+            let mut cursor = self.cursor.write();
+            *cursor = None;
         }
 
         if let Some(client) = self.client().upgrade().clone() {

--- a/src/dx/subscribe/subscription_set.rs
+++ b/src/dx/subscribe/subscription_set.rs
@@ -795,6 +795,9 @@ where
                 return;
             }
             *is_subscribed_slot = false;
+
+            let mut cursor = self.cursor.write();
+            *cursor = None;
         }
 
         let Some(client) = self.client().upgrade().clone() else {

--- a/src/dx/subscribe/subscription_set.rs
+++ b/src/dx/subscribe/subscription_set.rs
@@ -39,12 +39,11 @@ use crate::{
 /// ### Multiplexed subscription
 ///
 /// ```rust
-/// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
+/// use pubnub::{subscribe::SubscriptionParams, Keyset, PubNubClient, PubNubClientBuilder};
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
-/// use pubnub::subscribe::SubscriptionParams;
-/// let client = // PubNubClient
+/// let pubnub = // PubNubClient
 /// #     PubNubClientBuilder::with_reqwest_transport()
 /// #         .with_keyset(Keyset {
 /// #              subscribe_key: "demo",
@@ -53,7 +52,7 @@ use crate::{
 /// #          })
 /// #         .with_user_id("uuid")
 /// #         .build()?;
-/// let subscription = client.subscription(SubscriptionParams {
+/// let subscription = pubnub.subscription(SubscriptionParams {
 ///     channels: Some(&["my_channel_1", "my_channel_2"]),
 ///     channel_groups:Some(&["my_group"]),
 ///     options:None
@@ -72,7 +71,7 @@ use crate::{
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
-/// let client = // PubNubClient
+/// let pubnub = // PubNubClient
 /// #     PubNubClientBuilder::with_reqwest_transport()
 /// #         .with_keyset(Keyset {
 /// #              subscribe_key: "demo",
@@ -81,7 +80,7 @@ use crate::{
 /// #          })
 /// #         .with_user_id("uuid")
 /// #         .build()?;
-/// let channels = client.channels(&["my_channel_1", "my_channel_2"]);
+/// let channels = pubnub.channels(&["my_channel_1", "my_channel_2"]);
 /// // Two `Subscription` instances can be added to create `SubscriptionSet` which can be used
 /// // to attach listeners and subscribe in one place for both subscriptions used in addition
 /// // operation.
@@ -231,12 +230,11 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use pubnub::{PubNubClient, PubNubClientBuilder, Keyset};
+    /// use pubnub::{subscribe::SubscriptionParams, Keyset, PubNubClient, PubNubClientBuilder};
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
-    /// use pubnub::subscribe::SubscriptionParams;
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -245,7 +243,7 @@ where
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let subscription = client.subscription(SubscriptionParams {
+    /// let subscription = pubnub.subscription(SubscriptionParams {
     ///     channels: Some(&["my_channel_1", "my_channel_2"]),
     ///     channel_groups: Some(&["my_group"]),
     ///     options: None
@@ -633,7 +631,7 @@ where
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), pubnub::core::PubNubError> {
     /// use pubnub::subscribe::SubscriptionParams;
-    /// let client = // PubNubClient
+    /// let pubnub = // PubNubClient
     /// #     PubNubClientBuilder::with_reqwest_transport()
     /// #         .with_keyset(Keyset {
     /// #              subscribe_key: "demo",
@@ -642,7 +640,7 @@ where
     /// #          })
     /// #         .with_user_id("uuid")
     /// #         .build()?;
-    /// let subscription = client.subscription(SubscriptionParams {
+    /// let subscription = pubnub.subscription(SubscriptionParams {
     ///     channels: Some(&["my_channel_1", "my_channel_2"]),
     ///     channel_groups: Some(&["my_group"]),
     ///     options: None

--- a/src/dx/subscribe/subscription_set.rs
+++ b/src/dx/subscribe/subscription_set.rs
@@ -692,6 +692,32 @@ where
         *self.is_subscribed.read()
     }
 
+    /// Register `Subscription` within `SubscriptionManager`.
+    ///
+    /// # Arguments
+    ///
+    /// - `cursor` - Subscription real-time events catch up cursor.
+    fn register_with_cursor(&self, cursor: Option<SubscriptionCursor>) {
+        let Some(client) = self.client().upgrade().clone() else {
+            return;
+        };
+
+        {
+            let manager = client.subscription_manager(true);
+            if let Some(manager) = manager.write().as_mut() {
+                // Mark entities as "in-use" by subscription.
+                self.subscriptions.read().iter().for_each(|subscription| {
+                    subscription.entity.increase_subscriptions_count();
+                });
+
+                if let Some((_, handler)) = self.clones.read().iter().next() {
+                    let handler: Weak<dyn EventHandler<T, D> + Send + Sync> = handler.clone();
+                    manager.register(&handler, cursor);
+                }
+            };
+        }
+    }
+
     /// Filters the given list of `Update` events based on the subscription
     /// input and the current timetoken.
     ///
@@ -749,43 +775,44 @@ where
     T: Transport + Send + Sync + 'static,
     D: Deserializer + Send + Sync + 'static,
 {
-    fn subscribe(&self, cursor: Option<SubscriptionCursor>) {
+    fn subscribe(&self) {
         let mut is_subscribed = self.is_subscribed.write();
         if *is_subscribed {
             return;
         }
         *is_subscribed = true;
 
-        if cursor.is_some() {
-            let mut cursor_slot = self.cursor.write();
-            if let Some(current_cursor) = cursor_slot.as_ref() {
-                let catchup_cursor = cursor.clone().unwrap_or_default();
-                catchup_cursor
-                    .gt(current_cursor)
-                    .then(|| *cursor_slot = Some(catchup_cursor));
-            } else {
-                *cursor_slot = cursor.clone();
+        self.register_with_cursor(self.cursor.read().clone())
+    }
+
+    fn subscribe_with_timetoken<SC>(&self, cursor: SC)
+    where
+        SC: Into<SubscriptionCursor>,
+    {
+        let mut is_subscribed = self.is_subscribed.write();
+        if *is_subscribed {
+            return;
+        }
+        *is_subscribed = true;
+
+        let user_cursor = cursor.into();
+        let cursor = user_cursor.is_valid().then_some(user_cursor);
+
+        {
+            if cursor.is_some() {
+                let mut cursor_slot = self.cursor.write();
+                if let Some(current_cursor) = cursor_slot.as_ref() {
+                    let catchup_cursor = cursor.clone().unwrap_or_default();
+                    catchup_cursor
+                        .gt(current_cursor)
+                        .then(|| *cursor_slot = Some(catchup_cursor));
+                } else {
+                    *cursor_slot = cursor.clone();
+                }
             }
         }
 
-        let Some(client) = self.client().upgrade().clone() else {
-            return;
-        };
-
-        {
-            let manager = client.subscription_manager(true);
-            if let Some(manager) = manager.write().as_mut() {
-                // Mark entities as "in-use" by subscription.
-                self.subscriptions.read().iter().for_each(|subscription| {
-                    subscription.entity.increase_subscriptions_count();
-                });
-
-                if let Some((_, handler)) = self.clones.read().iter().next() {
-                    let handler: Weak<dyn EventHandler<T, D> + Send + Sync> = handler.clone();
-                    manager.register(&handler, cursor);
-                }
-            };
-        }
+        self.register_with_cursor(cursor);
     }
 
     fn unsubscribe(&self) {

--- a/src/dx/subscribe/traits/event_subscribe.rs
+++ b/src/dx/subscribe/traits/event_subscribe.rs
@@ -11,8 +11,21 @@ use crate::subscribe::SubscriptionCursor;
 /// Types that implement this trait can change activity of real-time events
 /// processing for specific or set of entities.
 pub trait EventSubscriber {
-    /// Use receiver to subscribe for real-time updates.
-    fn subscribe(&self, cursor: Option<SubscriptionCursor>);
+    /// Use the receiver to subscribe for real-time updates.
+    fn subscribe(&self);
+
+    /// Use the receiver to subscribe for real-time updates starting at a
+    /// specific time.
+    ///
+    /// # Arguments
+    ///
+    /// - `cursor` - `SubscriptionCursor` from which, the client should try to
+    ///   catch up on real-time events. `cursor` also can be provided as `usize`
+    ///   or `String` with a 17-digit PubNub  timetoken. If `cursor` doesn't
+    ///   satisfy the requirements, it will be ignored.
+    fn subscribe_with_timetoken<SC>(&self, cursor: SC)
+    where
+        SC: Into<SubscriptionCursor>;
 
     /// Use receiver to stop receiving real-time updates.
     fn unsubscribe(&self);

--- a/src/dx/subscribe/types.rs
+++ b/src/dx/subscribe/types.rs
@@ -128,52 +128,6 @@ pub struct SubscriptionCursor {
     pub region: u32,
 }
 
-impl PartialOrd for SubscriptionCursor {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-
-    fn lt(&self, other: &Self) -> bool {
-        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
-        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
-        lhs < rhs
-    }
-
-    fn le(&self, other: &Self) -> bool {
-        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
-        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
-        lhs <= rhs
-    }
-
-    fn gt(&self, other: &Self) -> bool {
-        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
-        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
-        lhs > rhs
-    }
-
-    fn ge(&self, other: &Self) -> bool {
-        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
-        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
-        lhs >= rhs
-    }
-}
-
-impl Ord for SubscriptionCursor {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap_or(Ordering::Equal)
-    }
-}
-
-impl Debug for SubscriptionCursor {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "SubscriptionCursor {{ timetoken: {}, region: {} }}",
-            self.timetoken, self.region
-        )
-    }
-}
-
 /// Subscription statuses.
 #[derive(Clone, PartialEq)]
 pub enum ConnectionStatus {
@@ -602,6 +556,20 @@ pub enum MessageActionEvent {
     Delete,
 }
 
+impl SubscriptionCursor {
+    /// Checks if the `timetoken` is valid.
+    ///
+    /// A valid `timetoken` should have a length of 17 and contain only numeric
+    /// characters.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the `timetoken` is valid, otherwise `false`.
+    pub(crate) fn is_valid(&self) -> bool {
+        self.timetoken.len() == 17 && self.timetoken.chars().all(char::is_numeric)
+    }
+}
+
 impl Default for SubscriptionCursor {
     fn default() -> Self {
         Self {
@@ -611,10 +579,89 @@ impl Default for SubscriptionCursor {
     }
 }
 
+impl PartialOrd for SubscriptionCursor {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+
+    fn lt(&self, other: &Self) -> bool {
+        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
+        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
+        lhs < rhs
+    }
+
+    fn le(&self, other: &Self) -> bool {
+        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
+        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
+        lhs <= rhs
+    }
+
+    fn gt(&self, other: &Self) -> bool {
+        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
+        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
+        lhs > rhs
+    }
+
+    fn ge(&self, other: &Self) -> bool {
+        let lhs = self.timetoken.parse::<u64>().expect("Invalid timetoken");
+        let rhs = other.timetoken.parse::<u64>().expect("Invalid timetoken");
+        lhs >= rhs
+    }
+}
+
+impl Ord for SubscriptionCursor {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Equal)
+    }
+}
+
+impl Debug for SubscriptionCursor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "SubscriptionCursor {{ timetoken: {}, region: {} }}",
+            self.timetoken, self.region
+        )
+    }
+}
+
 impl From<String> for SubscriptionCursor {
     fn from(value: String) -> Self {
-        Self {
-            timetoken: value,
+        let mut timetoken = value;
+        if timetoken.len() != 17 || !timetoken.chars().all(char::is_numeric) {
+            timetoken = "-1".into();
+        }
+
+        SubscriptionCursor {
+            timetoken,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<usize> for SubscriptionCursor {
+    fn from(value: usize) -> Self {
+        let mut timetoken = value.to_string();
+        if timetoken.len() != 17 {
+            timetoken = "-1".into();
+        }
+
+        SubscriptionCursor {
+            timetoken,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<u64> for SubscriptionCursor {
+    fn from(value: u64) -> Self {
+        let mut timetoken = value.to_string();
+        if timetoken.len() != 17 {
+            timetoken = "-1".into();
+        }
+
+        SubscriptionCursor {
+            timetoken,
             ..Default::default()
         }
     }

--- a/src/dx/subscribe/types.rs
+++ b/src/dx/subscribe/types.rs
@@ -90,7 +90,7 @@ pub enum SubscriptionOptions {
     /// Whether presence events should be received.
     ///
     /// Whether presence updates for `userId` should be delivered through
-    /// [`Subscription2`] listener streams or not.
+    /// [`Subscription`] and [`SubscriptionSet`] listener streams or not.
     ReceivePresenceEvents,
 }
 

--- a/src/dx/subscribe/types.rs
+++ b/src/dx/subscribe/types.rs
@@ -146,6 +146,20 @@ pub enum ConnectionStatus {
 
     /// Unexpected disconnection.
     DisconnectedUnexpectedly(PubNubError),
+
+    /// List of channels and groups changed in subscription.
+    SubscriptionChanged {
+        /// List of channels used in subscription.
+        ///
+        /// Channels can be:
+        /// - regular channels
+        /// - channel metadata `id`s
+        /// - user metadata `id`s
+        channels: Option<Vec<String>>,
+
+        /// List of channel groups used in subscription.
+        channel_groups: Option<Vec<String>>,
+    },
 }
 
 /// Presence update information.
@@ -732,6 +746,16 @@ impl Debug for ConnectionStatus {
             Self::ConnectionError(err) => write!(f, "ConnectionError({err:?})"),
             ConnectionStatus::DisconnectedUnexpectedly(err) => {
                 write!(f, "DisconnectedUnexpectedly({err:?})")
+            }
+            Self::SubscriptionChanged {
+                channels,
+                channel_groups,
+            } => {
+                write!(
+                    f,
+                    "SubscriptionChanged {{ channels: {channels:?}, \
+                    channel_groups: {channel_groups:?}  }}"
+                )
             }
         }
     }

--- a/src/dx/subscribe/types.rs
+++ b/src/dx/subscribe/types.rs
@@ -565,6 +565,7 @@ impl SubscriptionCursor {
     /// # Returns
     ///
     /// Returns `true` if the `timetoken` is valid, otherwise `false`.
+    #[cfg(feature = "std")]
     pub(crate) fn is_valid(&self) -> bool {
         self.timetoken.len() == 17 && self.timetoken.chars().all(char::is_numeric)
     }
@@ -634,6 +635,20 @@ impl From<String> for SubscriptionCursor {
 
         SubscriptionCursor {
             timetoken,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<&str> for SubscriptionCursor {
+    fn from(value: &str) -> Self {
+        let mut timetoken = value;
+        if timetoken.len() != 17 || !timetoken.chars().all(char::is_numeric) {
+            timetoken = "-1";
+        }
+
+        SubscriptionCursor {
+            timetoken: timetoken.to_string(),
             ..Default::default()
         }
     }
@@ -1157,5 +1172,89 @@ mod should {
     )]
     fn resolve_subscription_field_value(subscription: Option<String>, channel: &str) -> String {
         resolve_subscription_value(subscription, channel)
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_valid_subscription_cursor_as_struct() {
+        let cursor = SubscriptionCursor {
+            timetoken: "12345678901234567".into(),
+            region: 0,
+        };
+        assert!(cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_valid_subscription_cursor_from_string() {
+        let cursor: SubscriptionCursor = "12345678901234567".to_string().into();
+        assert!(cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_valid_subscription_cursor_from_string_slice() {
+        let cursor: SubscriptionCursor = "12345678901234567".into();
+        assert!(cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_valid_subscription_cursor_from_usize() {
+        let timetoken: usize = 12345678901234567;
+        let cursor: SubscriptionCursor = timetoken.into();
+        assert!(cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_valid_subscription_cursor_from_u64() {
+        let timetoken: u64 = 12345678901234567;
+        let cursor: SubscriptionCursor = timetoken.into();
+        assert!(cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_invalid_subscription_cursor_from_short_string() {
+        let cursor: SubscriptionCursor = "1234567890123467".to_string().into();
+        assert!(!cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_invalid_subscription_cursor_from_non_numeric_string() {
+        let cursor: SubscriptionCursor = "123456789a123467".to_string().into();
+        assert!(!cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_invalid_subscription_cursor_from_short_string_slice() {
+        let cursor: SubscriptionCursor = "1234567890123567".into();
+        assert!(!cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_invalid_subscription_cursor_from_non_numeric_string_slice() {
+        let cursor: SubscriptionCursor = "1234567890123a567".into();
+        assert!(!cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_invalid_subscription_cursor_from_too_small_usize() {
+        let timetoken: usize = 123456789012567;
+        let cursor: SubscriptionCursor = timetoken.into();
+        assert!(!cursor.is_valid())
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn create_invalid_subscription_cursor_from_too_small_u64() {
+        let timetoken: u64 = 123901234567;
+        let cursor: SubscriptionCursor = timetoken.into();
+        assert!(!cursor.is_valid())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,17 +51,20 @@
 //! Try the following sample code to get up and running quickly!
 //!
 //! ```no_run
-//! use pubnub::{Keyset, PubNubClientBuilder};
-//! use pubnub::dx::subscribe::{SubscribeStreamEvent, Update};
+//! use pubnub::subscribe::Subscriber;
 //! use futures::StreamExt;
 //! use tokio::time::sleep;
 //! use std::time::Duration;
 //! use serde_json;
-//!
+//! use pubnub::{
+//!     dx::subscribe::Update,
+//!     subscribe::EventSubscriber,
+//!     Keyset, PubNubClientBuilder,
+//! };
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     use pubnub::subscribe::{EventEmitter, SubscriptionParams};
-//! let publish_key = "my_publish_key";
+//!     let publish_key = "my_publish_key";
 //!     let subscribe_key = "my_subscribe_key";
 //!     let client = PubNubClientBuilder::with_reqwest_transport()
 //!         .with_keyset(Keyset {
@@ -71,15 +74,22 @@
 //!         })
 //!         .with_user_id("user_id")
 //!         .build()?;
+//!
 //!     println!("PubNub instance created");
-//!    
+//!
 //!     let subscription = client.subscription(SubscriptionParams {
 //!         channels: Some(&["my_channel"]),
 //!         channel_groups: None,
 //!         options: None
 //!     });
 //!
-//!     println!("Subscribed to channel");
+//!     let channel_entity = client.channel("my_channel_2");
+//!     let channel_entity_subscription = channel_entity.subscription(None);
+//!
+//!     subscription.subscribe();
+//!     channel_entity_subscription.subscribe();
+//!
+//!     println!("Subscribed to channels");
 //!
 //!     // Launch a new task to print out each received message
 //!     tokio::spawn(client.status_stream().for_each(|status| async move {
@@ -110,7 +120,21 @@
 //!         }
 //!     }));
 //!
-//!     sleep(Duration::from_secs(1)).await;
+//!     // Explicitly listen only for real-time `message` updates.
+//!     tokio::spawn(
+//!         channel_entity_subscription
+//!             .messages_stream()
+//!             .for_each(|message| async move {
+//!                 if let Ok(utf8_message) = String::from_utf8(message.data.clone()) {
+//!                     if let Ok(cleaned) = serde_json::from_str::<String>(&utf8_message) {
+//!                         println!("message: {}", cleaned);
+//!                     }
+//!                 }
+//!             }),
+//!     );
+//!
+//!    sleep(Duration::from_secs(2)).await;
+//!    
 //!     // Send a message to the channel
 //!     client
 //!         .publish_message("hello world!")
@@ -119,7 +143,15 @@
 //!         .execute()
 //!         .await?;
 //!
-//!     sleep(Duration::from_secs(10)).await;
+//!    // Send a message to another channel
+//!     client
+//!         .publish_message("hello world on the other channel!")
+//!         .channel("my_channel_2")
+//!         .r#type("text-message")
+//!         .execute()
+//!         .await?;
+//!
+//!     sleep(Duration::from_secs(15)).await;
 //!
 //!     Ok(())
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,11 +39,11 @@
 //! ```toml
 //! # default features
 //! [dependencies]
-//! pubnub = "0.5.0"
+//! pubnub = "0.6.0"
 //!
 //! # all features
 //! [dependencies]
-//! pubnub = { version = "0.5.0", features = ["full"] }
+//! pubnub = { version = "0.6.0", features = ["full"] }
 //! ```
 //!
 //! ### Example
@@ -167,11 +167,11 @@
 //! ```toml
 //! # only blocking and access + default features
 //! [dependencies]
-//! pubnub = { version = "0.5.0", features = ["blocking", "access"] }
+//! pubnub = { version = "0.6.0", features = ["blocking", "access"] }
 //!
 //! # only parse_token + default features
 //! [dependencies]
-//! pubnub = { version = "0.5.0", features = ["parse_token"] }
+//! pubnub = { version = "0.6.0", features = ["parse_token"] }
 //! ```
 //!
 //! ### Available features
@@ -210,7 +210,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pubnub = { version = "0.5.0", default-features = false, features = ["serde", "publish",
+//! pubnub = { version = "0.6.0", default-features = false, features = ["serde", "publish",
 //! "blocking"] }
 //! ```
 //!

--- a/tests/presence/presence_steps.rs
+++ b/tests/presence/presence_steps.rs
@@ -138,7 +138,7 @@ async fn join(
         subscriptions.values().cloned().collect(),
         options.clone(),
     );
-    subscription.subscribe(None);
+    subscription.subscribe();
     world.subscription = Some(subscription);
     world.subscriptions = Some(subscriptions);
 }

--- a/tests/subscribe/subscribe_steps.rs
+++ b/tests/subscribe/subscribe_steps.rs
@@ -4,7 +4,7 @@ use cucumber::gherkin::Table;
 use cucumber::{codegen::Regex, gherkin::Step, then, when};
 use futures::{select_biased, FutureExt, StreamExt};
 use pubnub::core::RequestRetryConfiguration;
-use pubnub::subscribe::{EventEmitter, EventSubscriber, SubscriptionParams};
+use pubnub::subscribe::{EventEmitter, EventSubscriber, SubscriptionCursor, SubscriptionParams};
 use std::fs::read_to_string;
 
 /// Extract list of events and invocations from log.
@@ -122,7 +122,7 @@ async fn subscribe(world: &mut PubNubWorld) {
             channel_groups: None,
             options: None,
         });
-        subscription.subscribe(None);
+        subscription.subscribe();
         world.subscription = Some(subscription);
     });
 }
@@ -139,7 +139,11 @@ async fn subscribe_with_timetoken(world: &mut PubNubWorld, timetoken: u64) {
             channel_groups: None,
             options: None,
         });
-        subscription.subscribe(Some(timetoken.to_string().into()));
+
+        subscription.subscribe_with_timetoken(SubscriptionCursor {
+            timetoken: timetoken.to_string(),
+            ..Default::default()
+        });
         world.subscription = Some(subscription);
     });
 }


### PR DESCRIPTION
feat(subscription): add more types to create `SubscriptionCursor` from

Make it possible to create `SubscriptionCursor` from the string slice.

feat(subscription): add methods to manipulate subscriptions in set

Add `add_subscriptions(..)` and `sub_subscriptions(..)` to `SubscriptionSet` to make it possible in addition to sets manipulation use list of subscriptions.

fix(subscribe): fix `cursor` reset issue
    
Fix issue because of which `cursor` is not reset on `Subscription` and `SubscriptionSet` on unsubscribe.

fix(subscription): fix issue with cancelled effects

Fix issue because of which cancelled effects still asynchronously spawned for processing.

docs(inline): change `client` to `pubnub` in inline docs

refactor(subscribe): add subscription token validation
 
Added a method to validate the provided subscription token to conform to PubNub time token requirements with precision.
    
refactor(examples): refactor `subscribe` example
    
Separate `subscribe` example into two to show separately `subscribe` feature and `presence state` maintenance with subscribe.