### PR TITLE
make permissions sendable and syncable

### DIFF
--- a/src/dx/access/permissions.rs
+++ b/src/dx/access/permissions.rs
@@ -28,7 +28,7 @@ const JOIN: u8 = 0b1000_0000;
 /// allowed resources within the provided permissions.
 ///
 /// [`PubNub Access Manager`]: https://www.pubnub.com/docs/general/security/access-control
-pub trait Permission {
+pub trait Permission: Send + Sync {
     /// The name or pattern of the channel name for which permissions were
     /// specified.
     fn id(&self) -> &String;


### PR DESCRIPTION
fix: make `Permissions` sendable and syncable

Make `Permissions` trait sendable and syncable by default